### PR TITLE
fix: Removing queue stuff for correlation, only works in theory

### DIFF
--- a/charts/gitops-reverser/templates/deployment.yaml
+++ b/charts/gitops-reverser/templates/deployment.yaml
@@ -43,6 +43,8 @@ spec:
             - --leader-elect
             {{- end }}
             - --health-probe-bind-address=:8081
+            - --metrics-bind-address=:8080
+            - --metrics-secure=false
             - --webhook-cert-path={{ .Values.webhook.server.certPath }}
             - --webhook-cert-name={{ .Values.webhook.server.certName }}
             - --webhook-cert-key={{ .Values.webhook.server.certKey }}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -62,9 +62,8 @@ var (
 
 const (
 	// Correlation store configuration.
-	correlationTTLSeconds = 60
 	correlationMaxEntries = 10000
-	correlationTTL        = correlationTTLSeconds * time.Second
+	correlationTTL        = 5 * time.Minute
 )
 
 func init() {
@@ -78,6 +77,11 @@ func main() {
 	// Parse flags and configure logger
 	cfg := parseFlags()
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&cfg.zapOpts)))
+
+	// Log metrics configuration for debugging
+	setupLog.Info("Metrics configuration",
+		"metrics-bind-address", cfg.metricsAddr,
+		"metrics-secure", cfg.secureMetrics)
 
 	// Initialize metrics
 	setupCtx := ctrl.SetupSignalHandler()

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -217,7 +217,7 @@ func TestGetCommitMessage_CreateOperation(t *testing.T) {
 	}
 
 	message := GetCommitMessage(event)
-	expected := "[CREATE] v1/pods/test-pod by user/john.doe@example.com"
+	expected := "[CREATE] v1/pods/test-pod"
 	assert.Equal(t, expected, message)
 }
 
@@ -244,7 +244,7 @@ func TestGetCommitMessage_UpdateOperation(t *testing.T) {
 	}
 
 	message := GetCommitMessage(event)
-	expected := "[UPDATE] v1/services/my-service by user/system:serviceaccount:kube-system:deployment-controller"
+	expected := "[UPDATE] v1/services/my-service"
 	assert.Equal(t, expected, message)
 }
 
@@ -271,7 +271,7 @@ func TestGetCommitMessage_DeleteOperation(t *testing.T) {
 	}
 
 	message := GetCommitMessage(event)
-	expected := "[DELETE] v1/configmaps/old-config by user/admin"
+	expected := "[DELETE] v1/configmaps/old-config"
 	assert.Equal(t, expected, message)
 }
 
@@ -297,7 +297,7 @@ func TestGetCommitMessage_ClusterScopedResource(t *testing.T) {
 	}
 
 	message := GetCommitMessage(event)
-	expected := "[CREATE] v1/namespaces/my-namespace by user/cluster-admin"
+	expected := "[CREATE] v1/namespaces/my-namespace"
 	assert.Equal(t, expected, message)
 }
 
@@ -324,7 +324,7 @@ func TestGetCommitMessage_EmptyUsername(t *testing.T) {
 	}
 
 	message := GetCommitMessage(event)
-	expected := "[CREATE] v1/pods/test-pod by user/"
+	expected := "[CREATE] v1/pods/test-pod"
 	assert.Equal(t, expected, message)
 }
 
@@ -351,7 +351,7 @@ func TestGetCommitMessage_SpecialCharactersInNames(t *testing.T) {
 	}
 
 	message := GetCommitMessage(event)
-	expected := "[UPDATE] v1/pods/test-pod.with.dots by user/user@domain.com"
+	expected := "[UPDATE] v1/pods/test-pod.with.dots"
 	assert.Equal(t, expected, message)
 }
 
@@ -474,7 +474,7 @@ func TestIntegration_FilePathAndCommitMessage(t *testing.T) {
 	commitMessage := GetCommitMessage(event)
 
 	expectedPath := "v1/pods/integration-test/integration-test-pod.yaml"
-	expectedMessage := "[CREATE] v1/pods/integration-test-pod by user/integration-test-user"
+	expectedMessage := "[CREATE] v1/pods/integration-test-pod"
 
 	assert.Equal(t, expectedPath, filePath)
 	assert.Equal(t, expectedMessage, commitMessage)
@@ -520,7 +520,7 @@ func TestCommitMessage_AllOperations(t *testing.T) {
 			}
 
 			message := GetCommitMessage(event)
-			expected := "[" + op + "] v1/testkinds/test-resource by user/test-user"
+			expected := "[" + op + "] v1/testkinds/test-resource"
 			assert.Equal(t, expected, message)
 		})
 	}
@@ -662,21 +662,21 @@ func TestDeleteOperation_CommitMessageFormat(t *testing.T) {
 			namespace: "staging",
 			resource:  "configmaps",
 			username:  "developer",
-			expected:  "[DELETE] v1/configmaps/app-config by user/developer",
+			expected:  "[DELETE] v1/configmaps/app-config",
 		},
 		{
 			name:      "db-secret",
 			namespace: "production",
 			resource:  "secrets",
 			username:  "admin",
-			expected:  "[DELETE] v1/secrets/db-secret by user/admin",
+			expected:  "[DELETE] v1/secrets/db-secret",
 		},
 		{
 			name:      "web-deployment",
 			namespace: "default",
 			resource:  "deployments",
 			username:  "system:serviceaccount:kube-system:deployment-controller",
-			expected:  "[DELETE] apps/v1/deployments/web-deployment by user/system:serviceaccount:kube-system:deployment-controller",
+			expected:  "[DELETE] apps/v1/deployments/web-deployment",
 		},
 	}
 
@@ -743,7 +743,7 @@ func TestDeleteOperation_ClusterScoped(t *testing.T) {
 
 	// Verify commit message
 	commitMessage := GetCommitMessage(event)
-	assert.Equal(t, "[DELETE] v1/namespaces/test-namespace by user/cluster-admin", commitMessage)
+	assert.Equal(t, "[DELETE] v1/namespaces/test-namespace", commitMessage)
 }
 
 func TestBatchOperations_MultipleDeletes(t *testing.T) {

--- a/internal/watch/manager.go
+++ b/internal/watch/manager.go
@@ -337,7 +337,7 @@ func (m *Manager) tryEnrichFromCorrelation(
 	}
 
 	key := correlation.GenerateKey(id, operation, sanitizedYAML)
-	entry, found := m.CorrelationStore.GetAndDelete(key)
+	entry, found := m.CorrelationStore.Get(key)
 	if !found {
 		metrics.EnrichMissesTotal.Add(ctx, 1)
 		log.V(1).Info("No correlation match", "identifier", id.String(), "key", key)

--- a/internal/webhook/event_handler_test.go
+++ b/internal/webhook/event_handler_test.go
@@ -815,7 +815,4 @@ func TestEventHandler_Handle_SanitizationApplied(t *testing.T) {
 	// Verify webhook stored correlation (actual responsibility)
 	assert.True(t, response.Allowed)
 	assert.Equal(t, 1, correlationStore.Size(), "correlation entry should be stored")
-
-	// NOTE: Sanitization testing moved to internal/sanitize package tests
-	// Webhook's job is correlation storage only
 }


### PR DESCRIPTION
Found during tests that the user is hardly filled in, which probably is due to missing correlation entries. Especially status updates could be triggering unpredictable reads, we don't want to delete cache entries then.
