### PR TITLE
fix: watch for changes in dependent resources

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,20 @@
+# Claude Code instructions
+
+The contribution, code-quality, and validation rules for this repository live in
+**[AGENTS.md](./AGENTS.md)**.
+
+**Read [AGENTS.md](./AGENTS.md) at the start of every task and follow it.** It is
+the source of truth — if it ever conflicts with this file, AGENTS.md wins.
+
+Key points it enforces:
+
+- **Mandatory validation before a change is complete:** `task lint`, `task test`,
+  and `task test-e2e` must all pass. Run the e2e commands **sequentially, not in
+  parallel**.
+- **e2e tests need Docker** — verify with `docker info` before running
+  `task test-e2e`; ask the user to start the Docker daemon if it is not running.
+- **Docs-only exception:** a pure markdown/docs change that touches no Go code,
+  manifests, charts, Taskfiles, CI, or scripts may skip the full suite — see
+  AGENTS.md for the exact wording.
+- Validation sequence: `task fmt` → `task generate` → `task manifests` →
+  `task vet` → `task lint` → `task test` → `task test-e2e`.

--- a/charts/gitops-reverser/README.md
+++ b/charts/gitops-reverser/README.md
@@ -179,6 +179,7 @@ nodeSelector:
 | `queue.redis.tls.enabled` | Enable TLS for Redis connection | `false` |
 | `auditEventJoin.bodyTTL` | TTL for parked additional audit bodies waiting for the matching official event | `5m` |
 | `auditEventJoin.decisionTTL` | TTL for audit decision dedupe keys | `1h` |
+| `auditEventJoin.bodyWait` | Grace period for a bodyless official audit event to wait for a matching additional body while preserving official event order | `500ms` |
 | `servers.metrics.bindAddress` | Metrics listener bind address | `:8080` |
 | `servers.metrics.tls.enabled` | Serve metrics with TLS | `false` |
 | `servers.metrics.tls.certPath` | Metrics TLS certificate mount path | `/tmp/k8s-metrics-server/metrics-server-certs` |

--- a/charts/gitops-reverser/templates/deployment.yaml
+++ b/charts/gitops-reverser/templates/deployment.yaml
@@ -77,6 +77,7 @@ spec:
             {{- end }}
             - --audit-event-body-ttl={{ .Values.auditEventJoin.bodyTTL }}
             - --audit-event-decision-ttl={{ .Values.auditEventJoin.decisionTTL }}
+            - --audit-event-body-wait={{ .Values.auditEventJoin.bodyWait }}
             {{- if .Values.logging.level }}
             - --zap-log-level={{ .Values.logging.level }}
             {{- end }}

--- a/charts/gitops-reverser/values.yaml
+++ b/charts/gitops-reverser/values.yaml
@@ -122,6 +122,7 @@ queue:
 auditEventJoin:
   bodyTTL: "5m"
   decisionTTL: "1h"
+  bodyWait: "500ms"
 
 # TLS certificate management (Kubernetes requires this for API server callbacks)
 certificates:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -157,6 +157,7 @@ func main() {
 		ctrl.Log.WithName("event-router"),
 	)
 	reconcilerManager.SetEventRouter(eventRouter)
+	reconcilerManager.SetOnReconcilerCreated(watchMgr.MaybeReplaySnapshot)
 
 	// Set EventRouter reference in WatchManager
 	watchMgr.EventRouter = eventRouter

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -75,6 +75,7 @@ const (
 	defaultAuditShutdownTimeout    = 10 * time.Second
 	defaultAuditEventBodyTTL       = 5 * time.Minute
 	defaultAuditEventDecisionTTL   = time.Hour
+	defaultAuditEventBodyWait      = 500 * time.Millisecond
 	defaultBranchBufferMaxBytesStr = "8Mi"
 )
 
@@ -191,13 +192,14 @@ func main() {
 	fatalIfErr(err, "unable to initialize audit redis queue")
 
 	auditJoiner, err := webhookhandler.NewRedisAuditEventJoiner(webhookhandler.RedisAuditJoinerConfig{
-		Addr:        cfg.auditRedisAddr,
-		Username:    cfg.auditRedisUsername,
-		AuthValue:   cfg.auditRedisPassword,
-		DB:          cfg.auditRedisDB,
-		TLSEnabled:  cfg.auditRedisTLS,
-		BodyTTL:     cfg.auditEventBodyTTL,
-		DecisionTTL: cfg.auditEventDecisionTTL,
+		Addr:             cfg.auditRedisAddr,
+		Username:         cfg.auditRedisUsername,
+		AuthValue:        cfg.auditRedisPassword,
+		DB:               cfg.auditRedisDB,
+		TLSEnabled:       cfg.auditRedisTLS,
+		BodyTTL:          cfg.auditEventBodyTTL,
+		DecisionTTL:      cfg.auditEventDecisionTTL,
+		OfficialBodyWait: cfg.auditEventBodyWait,
 	})
 	fatalIfErr(err, "unable to initialize audit event joiner")
 	setupLog.Info("Audit pipeline configured",
@@ -206,7 +208,8 @@ func main() {
 		"db", cfg.auditRedisDB,
 		"tlsEnabled", cfg.auditRedisTLS,
 		"bodyTTL", cfg.auditEventBodyTTL,
-		"decisionTTL", cfg.auditEventDecisionTTL)
+		"decisionTTL", cfg.auditEventDecisionTTL,
+		"officialBodyWait", cfg.auditEventBodyWait)
 
 	// Register the audit stream consumer. It shares the same Redis config as the
 	// producer but uses a dedicated consumer group and ID (pod-name-scoped so that
@@ -325,6 +328,7 @@ type appConfig struct {
 	auditRedisTLS            bool
 	auditEventBodyTTL        time.Duration
 	auditEventDecisionTTL    time.Duration
+	auditEventBodyWait       time.Duration
 	branchBufferMaxBytes     int64
 	zapOpts                  zap.Options
 }
@@ -399,6 +403,8 @@ func parseFlagsWithArgs(fs *flag.FlagSet, args []string) (appConfig, error) {
 		"TTL for parked additional audit body contributions.")
 	fs.DurationVar(&cfg.auditEventDecisionTTL, "audit-event-decision-ttl", defaultAuditEventDecisionTTL,
 		"TTL for audit decision keys that deduplicate canonical stream events.")
+	fs.DurationVar(&cfg.auditEventBodyWait, "audit-event-body-wait", defaultAuditEventBodyWait,
+		"Grace period for a bodyless official audit event to wait for a matching additional body.")
 	branchBufferMaxBytesStr := os.Getenv("BRANCH_BUFFER_MAX_BYTES")
 	if branchBufferMaxBytesStr == "" {
 		branchBufferMaxBytesStr = defaultBranchBufferMaxBytesStr
@@ -480,6 +486,9 @@ func validateAuditConfig(cfg appConfig) error {
 	}
 	if cfg.auditEventDecisionTTL <= 0 {
 		return fmt.Errorf("audit-event-decision-ttl must be > 0, got %s", cfg.auditEventDecisionTTL)
+	}
+	if cfg.auditEventBodyWait < 0 {
+		return fmt.Errorf("audit-event-body-wait must be >= 0, got %s", cfg.auditEventBodyWait)
 	}
 	return nil
 }

--- a/cmd/main_audit_server_test.go
+++ b/cmd/main_audit_server_test.go
@@ -59,6 +59,7 @@ func TestParseFlagsWithArgs_Defaults(t *testing.T) {
 	assert.False(t, cfg.auditRedisTLS)
 	assert.Equal(t, 5*time.Minute, cfg.auditEventBodyTTL)
 	assert.Equal(t, time.Hour, cfg.auditEventDecisionTTL)
+	assert.Equal(t, 500*time.Millisecond, cfg.auditEventBodyWait)
 	assert.False(t, cfg.zapOpts.Development)
 }
 
@@ -96,6 +97,7 @@ func TestParseFlagsWithArgs_CustomAuditValues(t *testing.T) {
 		"--audit-redis-tls",
 		"--audit-event-body-ttl=2m",
 		"--audit-event-decision-ttl=30m",
+		"--audit-event-body-wait=250ms",
 	}
 
 	cfg, err := parseFlagsWithArgs(fs, args)
@@ -121,6 +123,7 @@ func TestParseFlagsWithArgs_CustomAuditValues(t *testing.T) {
 	assert.True(t, cfg.auditRedisTLS)
 	assert.Equal(t, 2*time.Minute, cfg.auditEventBodyTTL)
 	assert.Equal(t, 30*time.Minute, cfg.auditEventDecisionTTL)
+	assert.Equal(t, 250*time.Millisecond, cfg.auditEventBodyWait)
 }
 
 func TestParseFlagsWithArgs_InvalidAuditSettings(t *testing.T) {
@@ -163,6 +166,10 @@ func TestParseFlagsWithArgs_InvalidAuditSettings(t *testing.T) {
 		{
 			name: "invalid audit event decision ttl",
 			args: []string{"--audit-event-decision-ttl=0s"},
+		},
+		{
+			name: "invalid audit event body wait",
+			args: []string{"--audit-event-body-wait=-1s"},
 		},
 	}
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -117,6 +117,25 @@ Key fields:
 - `spec.targetRef` — references a GitTarget with explicit namespace
 - `spec.rules[].scope` — `Cluster` (cluster-scoped resources) or `Namespaced` (namespaced resources across all namespaces)
 
+### Controller dependency watches
+
+The reference chain above is also a *watch* chain. Each controller `Watches` the
+kind it references, so a freshly-applied or spec-changed dependency re-enqueues
+its dependents within milliseconds instead of waiting on the periodic requeue
+(~2 min):
+
+- `GitTargetReconciler` watches `GitProvider`
+- `WatchRuleReconciler` / `ClusterWatchRuleReconciler` watch `GitTarget` and `GitProvider`
+
+These watches use a `GenerationChangedPredicate`: they fire on create and spec
+changes but ignore the status-only updates the controllers write to their own
+dependencies. Without the predicate, every dependency heartbeat would re-list
+and re-enqueue all dependents. The trade-off: a dependency that becomes *usable*
+via a status-only transition (e.g. a `GitProvider` whose credentials start
+working with no spec edit) re-enqueues dependents only on the next periodic
+requeue, not instantly. See
+[idea-cross-kind-dependency-watches.md](future/idea-cross-kind-dependency-watches.md).
+
 ---
 
 ## Kubernetes API Concepts That Matter Here

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -506,8 +506,8 @@ the design to add explicit cache warm-up before startup reconcile.
 
 The audit handler is the seam where everything that wants to drive a Git write enters the system.
 It accepts two semantic source roles, deduplicates by `auditID`, classifies event shape, recovers
-bodies for aggregated API requests, and writes one canonical event per `auditID` to the Redis
-stream.
+bodies for aggregated API requests, preserves official-event ordering, and writes one canonical
+event per `auditID` to the Redis stream.
 
 ### What this pipeline exists for
 
@@ -517,9 +517,11 @@ stream.
    one stream entry.
 3. **No silent shallow writes.** A shallow event is either normalized by a matching additional
    body or dropped — it never produces a stub Git commit.
-4. **Visibility.** Operators see counters for received events, parked bodies, dedupe decisions,
-   join latency, body misses, and late bodies. (Sweeper-driven counters for orphan bodies and
-   shallow drops are not yet wired — see [Known gaps](#known-gaps).)
+4. **Visibility.** Operators see counters for received events, event quality, parked bodies,
+   dedupe decisions, shallow drops, and late bodies, plus histograms for official↔additional
+   arrival skew and canonical-gate wait time. See [Interpreting metrics](interpreting-metrics.md)
+   for the query cookbook. (Orphan additional bodies still expire without a metric — see
+   [Known gaps](#known-gaps).)
 5. **Easy setup.** Deployment intent is the only knob; there are no API-group allowlists or
    join-mode flags to maintain.
 
@@ -557,7 +559,9 @@ flowchart TD
     ADD --> CLS
 
     CLS -->|official, complete or deletable or collection<br/>or shallow with parked body| CLM[Claim decision → emit]
-    CLS -->|official, identity_shallow with no parked body| DROP_S[Drop + shallow_dropped + WARN log]
+    CLS -->|official, identity_shallow with no parked body| WAIT_S[Hold official canonical gate<br/>briefly wait for body]
+    WAIT_S -->|additional body arrives| MERGE
+    WAIT_S -->|wait expires| DROP_S[Drop + shallow_dropped + WARN log]
     CLS -->|additional with body, no committed decision| PARK_A[Park body, wait for official]
     CLS -->|additional, decision committed| DROP_L[Drop + body_late]
     CLS -->|malformed additional| DROP_M[Drop with log]
@@ -571,9 +575,18 @@ flowchart TD
     CONS --> RULES[Rule match → EventRouter → BranchWorker]
 ```
 
-The official channel is strictly synchronous: every official event either emits in arrival
-order or drops immediately. Only additional bodies park, and only because they arrive earlier
-than the official sibling they're waiting for (see [Timing assumption](#timing-assumption)).
+The official channel is strictly synchronous at the canonical boundary. A bodyless official event
+that needs an additional body holds the official canonical gate for a short grace period; later
+official events wait behind it so canonical Redis stream order cannot overtake the earlier event.
+The additional endpoint is not held by that gate, because it must remain able to park the missing
+body while the official event is waiting.
+
+The canonical gate is an **in-pod mutex** ([audit_handler.go](internal/webhook/audit_handler.go)),
+so this ordering guarantee holds per webhook-receiver pod. Under the future HA topology (multiple
+webhook-receiver pods behind one Service) there is no cross-pod ordering — two pods may interleave
+their canonical writes. This is acceptable because the leader-elected consumer does not depend on
+strict global stream order; the gate exists to keep a single pod's officials from leapfrogging an
+earlier official that is still waiting for its body.
 
 Only `Stage=ResponseComplete` events reach the joiner. kube-apiserver may emit other stages
 (`RequestReceived`, `ResponseStarted`, `Panic`) under the same `auditID`; if those were
@@ -591,7 +604,7 @@ based on event shape, not API group:
 | `complete` | Request or response body present | Emit |
 | `body_shallow_deletable` | `verb=delete` with `objectRef.Resource` and `Name` set, no body | Emit (delete carve-out) |
 | `collection` | `verb=deletecollection` with body and `objectRef.Resource` | Emit (forwarded raw; per-item routing is a downstream gap) |
-| `identity_shallow` | No body, missing `objectRef` identity | On official: merge if body is parked; otherwise immediate drop + `audit_shallow_dropped_total` + WARN log |
+| `identity_shallow` | No body, missing `objectRef` identity | On official: merge if body is parked; otherwise hold the official canonical gate for `--audit-event-body-wait`, then drop + `audit_shallow_dropped_total` + WARN log |
 | `malformed` | Additional event with no body at all | Drop with log |
 
 Two carve-outs are load-bearing:
@@ -612,7 +625,9 @@ stateDiagram-v2
     [*] --> EmittedAsIs: official body-rich, no parked body
     [*] --> EmittedMerged: official body-rich, parked body exists
     [*] --> EmittedMerged: official identity_shallow, parked body exists
-    [*] --> ShallowDropped: official identity_shallow, no parked body
+    [*] --> WaitingForBody: official identity_shallow, no parked body
+    WaitingForBody --> EmittedMerged: additional body arrives within grace
+    WaitingForBody --> ShallowDropped: grace expires
     [*] --> DuplicateDropped: official matches committed decision
     [*] --> BodyLateDropped: additional with body, decision already committed
 
@@ -626,23 +641,22 @@ stateDiagram-v2
     BodyLateDropped --> [*]
 ```
 
-### Timing assumption
+### Timing and ordering
 
-The "shallow drop is immediate" choice rests on one assumption:
+The joiner is optimized for the common case where `/audit-webhook-additional` arrives before the
+official kube-apiserver event. When CI or a cluster delivers the official event first by a few
+milliseconds, the handler waits up to `--audit-event-body-wait` before declaring the body missing.
 
-> Events posted to `/audit-webhook-additional` for an `auditID` reach gitops-reverser before
-> the corresponding kube-apiserver event for the same `auditID`.
+That wait is deliberately attached to the official canonical gate, not only to the individual
+event. This preserves canonical Redis stream order: later official events cannot enqueue while an
+earlier official event is waiting for its additional body. The additional endpoint is allowed to
+continue because blocking it would prevent the missing body from being parked.
 
-`apiservice-audit-proxy` emits in line with the request it observed. kube-apiserver's audit
-webhook batches with `--audit-webhook-batch-max-wait` (default 30s). In the steady state the
-proxy has a margin of seconds to minutes.
-
-If the assumption is violated, the cost is: a shallow drop where a parked-shallow design
-would have merged. The corresponding audit fact is logged at WARN and counted in
-`audit_shallow_dropped_total` — operators see the failure, they don't lose it silently.
-
-The single thing to verify in the field is that `apiservice-audit-proxy` does not implement
-its own batching. If it does, we revisit.
+If the grace period expires, the cost is still explicit: a shallow drop where a longer wait would
+have merged. The corresponding audit fact is logged at WARN and counted in
+`audit_shallow_dropped_total` — operators see the failure, they don't lose it silently. Sustained
+`audit_join_body_late_total` or `audit_shallow_dropped_total` means the proxy/body path is slower
+than the configured grace period or missing entirely.
 
 The joiner uses two Redis key families:
 
@@ -688,6 +702,7 @@ should have already kept these out, but the consumer enforces it as defense-in-d
 | --- | --- | --- | --- |
 | `--audit-event-body-ttl` | `auditEventJoin.bodyTTL` | `5m` | TTL for parked additional bodies waiting for the matching official |
 | `--audit-event-decision-ttl` | `auditEventJoin.decisionTTL` | `1h` | Bounds the dedupe window |
+| `--audit-event-body-wait` | `auditEventJoin.bodyWait` | `500ms` | Grace period for a bodyless official event to wait for a matching additional body while holding official canonical order |
 
 There is no API-group allowlist and no join-mode flag — both were removed because the endpoint
 already encodes intent and `wait-official` semantics are always correct.
@@ -703,10 +718,15 @@ already encodes intent and `wait-official` semantics are always correct.
 | `gitopsreverser_audit_join_duplicate_dropped_total` | `reason` | Drops from existing decision keys: `decision_exists`, `in_flight_claim` |
 | `gitopsreverser_audit_shallow_dropped_total` | `gvr`, `action` | Identity-shallow officials dropped because no parked body was available |
 | `gitopsreverser_audit_join_body_late_total` | `gvr`, `action` | Additional body arrived after the decision was committed |
+| `gitopsreverser_audit_join_skew_seconds` | `arrival`, `outcome` | Histogram of official↔additional arrival skew: `arrival=body_first` is the proxy's lead time, `arrival=official_first` is how long the official waited on the canonical gate |
+| `gitopsreverser_audit_official_gate_wait_seconds` | — | Histogram of how long an official event waited to acquire the in-pod canonical gate (backpressure signal) |
 
 Useful alerts: `audit_shallow_dropped_total` non-zero (operator misconfiguration — install
 proxy or update audit policy); `audit_join_duplicate_dropped_total` spikes (likely webhook
-retry storm); sustained `audit_join_body_late_total` (proxy timing slipping past the TTL).
+retry storm); sustained `audit_join_body_late_total` (proxy timing slipping past the TTL);
+`audit_join_skew_seconds` p95 for `arrival=official_first` creeping toward `--audit-event-body-wait`
+(early warning that the grace period is about to be exhausted). The full query cookbook lives in
+[Interpreting metrics](interpreting-metrics.md).
 
 ### Operator guidance
 

--- a/docs/future/design-rule-change-snapshot-trigger.md
+++ b/docs/future/design-rule-change-snapshot-trigger.md
@@ -1,0 +1,156 @@
+# Design: rule-change snapshot trigger
+
+> Status: design — captured after issues #145/#146-style symptoms surfaced.
+> Date: 2026-05-20
+> Failing tests that anchor this work:
+> - [internal/watch/rule_change_snapshot_test.go](../../internal/watch/rule_change_snapshot_test.go) — four unit tests
+> - [test/e2e/e2e_test.go](../../test/e2e/e2e_test.go) — `PIt("should backfill pre-existing ConfigMap when WatchRule is added afterwards", ...)`
+
+## The problem in one sentence
+
+`WatchManager.ReconcileForRuleChange` emits its snapshot as a fire-and-forget broadcast against the EventRouter, with no notion of "did this snapshot actually reach a `FolderReconciler` for the affected GitTarget?" and no retry — so any time the rule-set changes without changing the GVR set, or the receiver isn't registered yet, the backfill is silently lost.
+
+## Two failure modes, one root cause
+
+Both reduce to: *no delivery contract between snapshot producer and snapshot consumer.*
+
+### A. Rule-add when GVR is already watched
+
+[manager.go:660-664](../../internal/watch/manager.go#L660-L664) short-circuits when the GVR set didn't change:
+
+```go
+if len(added) == 0 && len(removed) == 0 {
+    return nil
+}
+```
+
+Adding a second rule for an already-watched GVR, or editing a rule's selectors without touching its GVR, takes this path. The snapshot is never even attempted. Resources that match the new rule and already exist in the cluster stay out of git until they're next mutated. Symmetric across `WatchRule` and `ClusterWatchRule`.
+
+### B. Restart with `SnapshotSynced=True`
+
+The `GitTargetReconciler` writes `SnapshotSynced=True` after a successful initial snapshot. On restart this is read back from the object's status, so [`evaluateSnapshotGate` at gittarget_controller.go:384](../../internal/controller/gittarget_controller.go#L384) takes the early-return — it ensures a `GitTargetEventStream` is registered, but it does *not* create a `FolderReconciler`. Meanwhile `WatchManager.Start` runs its own initial `ReconcileForRuleChange` (`manager.go:99`), which *does* emit a snapshot. That snapshot's `RequestClusterState` reaches [`RouteClusterStateEvent`](../../internal/watch/event_router.go#L254-L263), which looks up the reconciler, finds none, and drops the event with a V(1) log line. The same dropping happens for `RouteRepoStateEvent`. The user sees: "live updates write fine, but pre-existing resources never appear after a restart."
+
+The 30-second periodic `ReconcileForRuleChange` then hits failure mode A (GVRs stable), so there's no self-heal.
+
+## How the walk works today
+
+User asked specifically: *how do we walk through all resources in all namespaces when a ClusterWatchRule is adjusted?* The full chain:
+
+1. **Trigger.** `ClusterWatchRuleReconciler` finishes reconciling and calls `WatchManager.ReconcileForRuleChange(ctx)` ([clusterwatchrule_controller.go:183](../../internal/controller/clusterwatchrule_controller.go#L183)).
+2. **GVR diff.** `ReconcileForRuleChange` computes the desired GVR set from the rule store and diffs it against `activeInformers`. The early-return at 660 fires here for failure mode A.
+3. **Informer churn.** `startInformersForGVRs(added)` / `stopInformer(removed)` brings the informer set in line with the desired set. New informers run `WaitForCacheSync`, so by the time this returns every existing resource has been observed by the informer and forwarded as an ADDED event.
+4. **Stream buffering.** `beginReconciliationForAffectedTargets` transitions every registered `GitTargetEventStream` to `Reconciling` so the informer ADDED events from step 3 are *buffered* instead of producing N individual `[CREATE]` commits.
+5. **Snapshot emission.** `emitSnapshotForRuleChange` calls `ProcessControlEvent(RequestRepoState)` and `ProcessControlEvent(RequestClusterState)` for every affected GitTarget. `handleRequestClusterState` calls [`GetClusterStateForGitDest` (manager.go:415)](../../internal/watch/manager.go#L415):
+   - Build `gvrMap[GVR] -> {namespaces, clusterWide}` from active rules. ClusterWatchRule entries set `clusterWide=true` ([manager.go:493](../../internal/watch/manager.go#L493)).
+   - For each entry, call [`listResourcesForGVR`](../../internal/watch/manager.go#L604): cluster-wide `List` when `clusterWide`, namespaced `List` when WatchRule.
+   - Sanitize each item, key it by `ResourceIdentifier`, return as a `ClusterStateEvent`.
+6. **Diff and write.** `FolderReconciler.OnClusterState` ([folder_reconciler.go:120](../../internal/reconcile/folder_reconciler.go#L120)) stores the cluster-state half. When the matching `RepoState` half also arrives, `reconcile()` diffs (`findDifferences`) and emits one atomic `WriteRequest` containing `CREATE`/`UPDATE`/`DELETE` per resource.
+7. **Flush.** `completeReconciliationForAffectedTargets` transitions streams back to `LiveProcessing`. The buffered events from step 3 flush; they're no-ops at the git layer because the snapshot batch just wrote those files.
+
+So the *walk itself* is functional and correctly cluster-wide for ClusterWatchRule. The hole is steps 4-6: **the broadcast at step 5 has no acknowledgment.** If no receiver is registered the snapshot is computed and thrown away.
+
+### Architectural note worth flagging now
+
+`listResourcesForGVR` doesn't apply rule selectors today — it lists every resource of the GVR and returns them all unfiltered (the rulestore is MVP-simplified, `rulestore/store.go:328` confirms `NamespaceSelector` isn't implemented yet). For *live events*, `matchRules` applies the full predicate including `nsLabels`. The two paths diverge.
+
+This is fine as long as ClusterWatchRule means "all of this GVR, everywhere." The moment `namespaceSelector` / `labelSelector` lands on the rule spec (which the existing CRD comments already hint at), the snapshot walk must apply the same predicates as the live path or the steady state will not match the snapshot state and we'll get spurious deletes on every reconcile. Fix should land in the same change-set that introduces selectors, not retrofitted later.
+
+## Fix shape
+
+The minimum change to close both failure modes is **a delivery contract per GitTarget**.
+
+### Core idea
+
+For each GitTarget, the WatchManager tracks two values:
+
+- `lastDeliveredRuleSetHash` — fingerprint of the rule-set that was last successfully snapshotted *and* delivered to a registered `FolderReconciler`.
+- `currentRuleSetHash` — recomputed on every `ReconcileForRuleChange`, derived from the rules in the store affecting this GitTarget.
+
+The trigger logic becomes:
+
+```
+for each gitDest in collectAffectedGitTargets():
+    if currentRuleSetHash[gitDest] == lastDeliveredRuleSetHash[gitDest]:
+        continue  # already in sync
+    if no FolderReconciler registered for gitDest:
+        mark gitDest as needing snapshot; do not advance lastDelivered
+        continue
+    emit RequestRepoState + RequestClusterState
+    on successful delivery (route function found the receiver):
+        lastDeliveredRuleSetHash[gitDest] = currentRuleSetHash[gitDest]
+```
+
+And one additional hook: when `EventRouter.RegisterGitTargetEventStream` (or whenever the reconciler is created via `ReconcilerManager.CreateReconciler`) registers a new receiver, ask the WatchManager whether that gitDest has a pending snapshot — if so, drain it.
+
+This single change covers:
+
+- **Failure A.** `compareGVRs` becomes informational only; the snapshot decision is rule-hash-based. `len(added)==0 && len(removed)==0` no longer short-circuits the snapshot path.
+- **Failure B.** When `WatchManager.Start` fires the initial snapshot before the GitTargetReconciler has registered a receiver, `lastDelivered` doesn't advance. The GitTargetReconciler subsequently registers, which drains the pending entry, the snapshot fires again with a receiver present, and `lastDelivered` advances.
+
+The early-return on truly-stable state (rule-hash unchanged) is preserved — we keep idempotency for periodic ticks.
+
+### Receiver registration hook
+
+The cleanest place is `ReconcilerManager.CreateReconciler` (called from `GitTargetReconciler.evaluateSnapshotGate`). It already has the gitDest. Adding "on new reconciler creation, notify WatchManager" makes the coordination explicit and avoids implicit timing assumptions.
+
+Sketch:
+
+```go
+// In ReconcilerManager.CreateReconciler, after inserting the reconciler:
+if m.onReconcilerCreated != nil {
+    m.onReconcilerCreated(gitDest)
+}
+```
+
+And `onReconcilerCreated := watchManager.MaybeReplaySnapshot` is wired at startup.
+
+### Why not just remove the early-return at manager.go:660?
+
+That fixes failure A but not failure B, and it makes every 30-second periodic tick a full cluster-wide list. The hash-based version pays the same cost only when the hash changes, which is the right knob.
+
+### What the rule-set hash actually contains
+
+Per gitDest, in canonical order:
+
+- For each `WatchRule` targeting it: name, namespace, generation (or a hash of `Spec`).
+- For each `ClusterWatchRule` targeting it: name, generation (or `Spec` hash).
+
+`generation` is the safer pick — it bumps on every `spec` change and is stable for status updates, so periodic reconciles caused by status-only events won't trigger spurious snapshots. The fingerprint is cheap; computing it on every `ReconcileForRuleChange` is fine.
+
+## Non-goals
+
+- **No removal of the periodic 30-second `ReconcileForRuleChange`.** It stays as a safety net (informer restarts, missed events). Just becomes hash-aware so it's free when there's nothing to do.
+- **No rewrite of the snapshot walk.** The walk is correct; only the trigger and delivery contract change.
+- **No new CRD fields.** This is internal coordination; the user-visible surface doesn't change.
+
+## Risk / open questions
+
+- **Hash for status-only rule updates.** If a controller patches `.status` on a `ClusterWatchRule`, that doesn't change `metadata.generation` and shouldn't cause a re-snapshot. Using `generation` correctly handles this.
+- **Delivery confirmation vs. delivery success.** The route function "found a receiver" doesn't mean the reconciler actually wrote anything to git — the diff might be empty, or a git push could fail later. We're only promising the snapshot was *handed off* to the right receiver; downstream failures are observable through existing git-push error paths and don't need to be folded in here.
+- **Concurrent rule changes.** Two `ReconcileForRuleChange` calls landing close together must not race the hash update. A per-gitDest mutex (or the existing `activeInformers` lock) is enough.
+- **Selector parity (flagged earlier).** When selectors land, `GetClusterStateForGitDest` must filter through the same predicate the live path uses, or the diff will produce spurious deletes.
+
+## Acceptance criteria
+
+The four failing unit tests in
+[internal/watch/rule_change_snapshot_test.go](../../internal/watch/rule_change_snapshot_test.go)
+go green:
+
+- `TestReconcileForRuleChange_AddingSecondRuleSameGVR_EmitsSnapshot`
+- `TestReconcileForRuleChange_NarrowingSelectorOnExistingRule_EmitsSnapshot`
+- `TestReconcileForRuleChange_AddingSecondWatchRuleSameGVR_EmitsSnapshot`
+- `TestReconcileForRuleChange_RestartLikeBootstrap_NoSnapshotDrops`
+
+The pending e2e spec
+`PIt("should backfill pre-existing ConfigMap when WatchRule is added afterwards", ...)`
+flips from `PIt` to `It` and passes against a real k3d cluster.
+
+The `EventRouter.SnapshotDeliveryDrops()` counter stays at 0 in steady state under a representative load test (creating and editing rules, restarting the controller).
+
+## References
+
+- Trigger bug summary: [idea-cross-kind-dependency-watches.md](idea-cross-kind-dependency-watches.md) (related coordination concern around dependency-watches).
+- The early-return: [manager.go:660-664](../../internal/watch/manager.go#L660-L664).
+- The snapshot consumer that gets dropped: [event_router.go:254-263](../../internal/watch/event_router.go#L254-L263) (post-instrumentation: increments `snapshotDeliveryDrops`).
+- The GitTarget gate that skips re-snapshot on restart: [gittarget_controller.go:384](../../internal/controller/gittarget_controller.go#L384).
+- The snapshot walk itself: [GetClusterStateForGitDest at manager.go:415](../../internal/watch/manager.go#L415), [listResourcesForGVR at manager.go:604](../../internal/watch/manager.go#L604).

--- a/docs/future/design-rule-change-snapshot-trigger.md
+++ b/docs/future/design-rule-change-snapshot-trigger.md
@@ -1,10 +1,38 @@
 # Design: rule-change snapshot trigger
 
-> Status: design — captured after issues #145/#146-style symptoms surfaced.
+> Status: implemented — captured after issues #145/#146-style symptoms surfaced.
 > Date: 2026-05-20
-> Failing tests that anchor this work:
+> Implemented: 2026-05-21
+> Tests that anchor this work:
 > - [internal/watch/rule_change_snapshot_test.go](../../internal/watch/rule_change_snapshot_test.go) — four unit tests
-> - [test/e2e/e2e_test.go](../../test/e2e/e2e_test.go) — `PIt("should backfill pre-existing ConfigMap when WatchRule is added afterwards", ...)`
+> - [test/e2e/e2e_test.go](../../test/e2e/e2e_test.go) — `It("should backfill pre-existing ConfigMap when WatchRule is added afterwards", Label("smoke"), ...)`
+
+## Implementation summary
+
+The fix landed as an in-memory delivery contract between `WatchManager` and the
+`FolderReconciler` registry:
+
+- `WatchManager` now computes a per-GitTarget rule-set hash from the compiled
+  `WatchRule` and `ClusterWatchRule` entries that affect that target.
+- `ReconcileForRuleChange` treats GVR changes as informer work, not as the only
+  snapshot trigger. If the rule-set hash changed, the target is marked pending
+  even when the GVR set is unchanged.
+- Snapshot delivery only advances `lastDeliveredRuleSetHash` after the target has
+  a registered `FolderReconciler` and both repo and cluster state requests were
+  handed to the router.
+- `ReconcilerManager.CreateReconciler` calls `WatchManager.MaybeReplaySnapshot`
+  when a new reconciler appears, so restart-like bootstraps drain pending
+  snapshots instead of dropping them.
+- `GitTargetReconciler` now creates a `FolderReconciler` even when
+  `SnapshotSynced=True`, preserving the "no new initial snapshot" gate while
+  still allowing rule-change snapshots to be delivered.
+
+Validation at implementation time:
+
+- `go test ./internal/watch -run 'TestReconcileForRuleChange' -count=1`
+- `task lint`
+- `task test`
+- `task test-e2e` with the new backfill spec included in the smoke set
 
 ## The problem in one sentence
 
@@ -16,7 +44,8 @@ Both reduce to: *no delivery contract between snapshot producer and snapshot con
 
 ### A. Rule-add when GVR is already watched
 
-[manager.go:660-664](../../internal/watch/manager.go#L660-L664) short-circuits when the GVR set didn't change:
+The old `ReconcileForRuleChange` implementation short-circuited when the GVR
+set didn't change:
 
 ```go
 if len(added) == 0 && len(removed) == 0 {
@@ -28,26 +57,26 @@ Adding a second rule for an already-watched GVR, or editing a rule's selectors w
 
 ### B. Restart with `SnapshotSynced=True`
 
-The `GitTargetReconciler` writes `SnapshotSynced=True` after a successful initial snapshot. On restart this is read back from the object's status, so [`evaluateSnapshotGate` at gittarget_controller.go:384](../../internal/controller/gittarget_controller.go#L384) takes the early-return — it ensures a `GitTargetEventStream` is registered, but it does *not* create a `FolderReconciler`. Meanwhile `WatchManager.Start` runs its own initial `ReconcileForRuleChange` (`manager.go:99`), which *does* emit a snapshot. That snapshot's `RequestClusterState` reaches [`RouteClusterStateEvent`](../../internal/watch/event_router.go#L254-L263), which looks up the reconciler, finds none, and drops the event with a V(1) log line. The same dropping happens for `RouteRepoStateEvent`. The user sees: "live updates write fine, but pre-existing resources never appear after a restart."
+The `GitTargetReconciler` writes `SnapshotSynced=True` after a successful initial snapshot. On restart this is read back from the object's status, so the old `evaluateSnapshotGate` path took the early-return — it ensured a `GitTargetEventStream` was registered, but it did *not* create a `FolderReconciler`. Meanwhile `WatchManager.Start` ran its own initial `ReconcileForRuleChange`, which *did* emit a snapshot. That snapshot's `RequestClusterState` reached `RouteClusterStateEvent`, which looked up the reconciler, found none, and dropped the event with a V(1) log line. The same dropping happened for `RouteRepoStateEvent`. The user saw: "live updates write fine, but pre-existing resources never appear after a restart."
 
 The 30-second periodic `ReconcileForRuleChange` then hits failure mode A (GVRs stable), so there's no self-heal.
 
-## How the walk works today
+## How the snapshot walk works
 
 User asked specifically: *how do we walk through all resources in all namespaces when a ClusterWatchRule is adjusted?* The full chain:
 
 1. **Trigger.** `ClusterWatchRuleReconciler` finishes reconciling and calls `WatchManager.ReconcileForRuleChange(ctx)` ([clusterwatchrule_controller.go:183](../../internal/controller/clusterwatchrule_controller.go#L183)).
-2. **GVR diff.** `ReconcileForRuleChange` computes the desired GVR set from the rule store and diffs it against `activeInformers`. The early-return at 660 fires here for failure mode A.
+2. **GVR diff and rule hash.** `ReconcileForRuleChange` computes the desired GVR set from the rule store and diffs it against `activeInformers`. The implemented path also computes per-target rule-set hashes, so unchanged GVRs no longer suppress a needed snapshot.
 3. **Informer churn.** `startInformersForGVRs(added)` / `stopInformer(removed)` brings the informer set in line with the desired set. New informers run `WaitForCacheSync`, so by the time this returns every existing resource has been observed by the informer and forwarded as an ADDED event.
-4. **Stream buffering.** `beginReconciliationForAffectedTargets` transitions every registered `GitTargetEventStream` to `Reconciling` so the informer ADDED events from step 3 are *buffered* instead of producing N individual `[CREATE]` commits.
-5. **Snapshot emission.** `emitSnapshotForRuleChange` calls `ProcessControlEvent(RequestRepoState)` and `ProcessControlEvent(RequestClusterState)` for every affected GitTarget. `handleRequestClusterState` calls [`GetClusterStateForGitDest` (manager.go:415)](../../internal/watch/manager.go#L415):
-   - Build `gvrMap[GVR] -> {namespaces, clusterWide}` from active rules. ClusterWatchRule entries set `clusterWide=true` ([manager.go:493](../../internal/watch/manager.go#L493)).
-   - For each entry, call [`listResourcesForGVR`](../../internal/watch/manager.go#L604): cluster-wide `List` when `clusterWide`, namespaced `List` when WatchRule.
+4. **Stream buffering.** `beginReconciliationForTargets` transitions every registered `GitTargetEventStream` for a target needing delivery to `Reconciling` so informer ADDED events from step 3 are *buffered* instead of producing N individual `[CREATE]` commits.
+5. **Snapshot emission.** `emitSnapshotForRuleChange` calls `ProcessControlEvent(RequestRepoState)` and `ProcessControlEvent(RequestClusterState)` for every target that needs delivery and has a registered `FolderReconciler`. `handleRequestClusterState` calls [`GetClusterStateForGitDest`](../../internal/watch/manager.go):
+   - Build `gvrMap[GVR] -> {namespaces, clusterWide}` from active rules. ClusterWatchRule entries set `clusterWide=true`.
+   - For each entry, call `listResourcesForGVR`: cluster-wide `List` when `clusterWide`, namespaced `List` when WatchRule.
    - Sanitize each item, key it by `ResourceIdentifier`, return as a `ClusterStateEvent`.
 6. **Diff and write.** `FolderReconciler.OnClusterState` ([folder_reconciler.go:120](../../internal/reconcile/folder_reconciler.go#L120)) stores the cluster-state half. When the matching `RepoState` half also arrives, `reconcile()` diffs (`findDifferences`) and emits one atomic `WriteRequest` containing `CREATE`/`UPDATE`/`DELETE` per resource.
-7. **Flush.** `completeReconciliationForAffectedTargets` transitions streams back to `LiveProcessing`. The buffered events from step 3 flush; they're no-ops at the git layer because the snapshot batch just wrote those files.
+7. **Flush.** `completeReconciliationForTargets` transitions streams back to `LiveProcessing`. The buffered events from step 3 flush; they're no-ops at the git layer because the snapshot batch just wrote those files.
 
-So the *walk itself* is functional and correctly cluster-wide for ClusterWatchRule. The hole is steps 4-6: **the broadcast at step 5 has no acknowledgment.** If no receiver is registered the snapshot is computed and thrown away.
+So the *walk itself* is functional and correctly cluster-wide for ClusterWatchRule. The original hole was steps 4-6: **the broadcast at step 5 had no acknowledgment.** The implemented delivery contract now keeps the snapshot pending when no receiver is registered.
 
 ### Architectural note worth flagging now
 
@@ -55,7 +84,7 @@ So the *walk itself* is functional and correctly cluster-wide for ClusterWatchRu
 
 This is fine as long as ClusterWatchRule means "all of this GVR, everywhere." The moment `namespaceSelector` / `labelSelector` lands on the rule spec (which the existing CRD comments already hint at), the snapshot walk must apply the same predicates as the live path or the steady state will not match the snapshot state and we'll get spurious deletes on every reconcile. Fix should land in the same change-set that introduces selectors, not retrofitted later.
 
-## Fix shape
+## Implemented fix shape
 
 The minimum change to close both failure modes is **a delivery contract per GitTarget**.
 
@@ -69,7 +98,7 @@ For each GitTarget, the WatchManager tracks two values:
 The trigger logic becomes:
 
 ```
-for each gitDest in collectAffectedGitTargets():
+for each target in currentRuleSetSnapshots():
     if currentRuleSetHash[gitDest] == lastDeliveredRuleSetHash[gitDest]:
         continue  # already in sync
     if no FolderReconciler registered for gitDest:
@@ -108,14 +137,19 @@ And `onReconcilerCreated := watchManager.MaybeReplaySnapshot` is wired at startu
 
 That fixes failure A but not failure B, and it makes every 30-second periodic tick a full cluster-wide list. The hash-based version pays the same cost only when the hash changes, which is the right knob.
 
-### What the rule-set hash actually contains
+### What the implemented rule-set hash contains
 
-Per gitDest, in canonical order:
+Per gitDest, in canonical order, the implementation fingerprints the compiled
+rule inputs currently held in `RuleStore`:
 
-- For each `WatchRule` targeting it: name, namespace, generation (or a hash of `Spec`).
-- For each `ClusterWatchRule` targeting it: name, generation (or `Spec` hash).
+- For each `WatchRule` targeting it: source name/namespace, resolved target,
+  provider, branch, path, and compiled resource rules.
+- For each `ClusterWatchRule` targeting it: source name, resolved target,
+  provider, branch, path, and compiled cluster resource rules.
 
-`generation` is the safer pick — it bumps on every `spec` change and is stable for status updates, so periodic reconciles caused by status-only events won't trigger spurious snapshots. The fingerprint is cheap; computing it on every `ReconcileForRuleChange` is fine.
+This uses the compiled store state rather than fetching the original CR objects
+or relying on `metadata.generation`. That keeps the snapshot trigger cheap and
+aligned with what live matching actually sees.
 
 ## Non-goals
 
@@ -125,10 +159,40 @@ Per gitDest, in canonical order:
 
 ## Risk / open questions
 
-- **Hash for status-only rule updates.** If a controller patches `.status` on a `ClusterWatchRule`, that doesn't change `metadata.generation` and shouldn't cause a re-snapshot. Using `generation` correctly handles this.
+- **Hash for status-only rule updates.** The implemented hash is derived from compiled rule store state, not object status. If future work fetches live CR objects for hashing, avoid including `status`, `resourceVersion`, or other status-only metadata.
 - **Delivery confirmation vs. delivery success.** The route function "found a receiver" doesn't mean the reconciler actually wrote anything to git — the diff might be empty, or a git push could fail later. We're only promising the snapshot was *handed off* to the right receiver; downstream failures are observable through existing git-push error paths and don't need to be folded in here.
 - **Concurrent rule changes.** Two `ReconcileForRuleChange` calls landing close together must not race the hash update. A per-gitDest mutex (or the existing `activeInformers` lock) is enough.
 - **Selector parity (flagged earlier).** When selectors land, `GetClusterStateForGitDest` must filter through the same predicate the live path uses, or the diff will produce spurious deletes.
+
+## Downsides and future improvements
+
+- **Hash format is implementation-local.** The current hash is built from
+  formatted compiled rule structs. It is fine for an in-process trigger, but a
+  future persistent or cross-version delivery contract should use explicit
+  canonical JSON or a typed hash builder.
+- **Pending delivery state is in memory.** A restart recomputes desired state on
+  the next reconciliation, but pending state is not persisted. If this project
+  moves toward multi-replica watch managers or stronger crash recovery, this
+  contract should move into leader-owned status, a lease-backed store, or a
+  durable work queue.
+- **Delivery still means "handed to the reconciler."** The implementation does
+  not wait for git writes or pushes to succeed before advancing the rule-set
+  delivery hash. Downstream failures remain observable through existing git
+  error paths. A future version could expose a stronger end-to-end snapshot
+  completion condition if users need it.
+- **Rule deletion cleanup needs explicit thought.** A hash computed only from
+  current rules cannot, by itself, identify a GitTarget that just lost its last
+  rule. If deletion should remove previously written files, future work should
+  retain tombstones for affected targets or make rule deletion trigger a
+  target-scoped cleanup snapshot before forgetting the target.
+- **Replay uses the reconciler creation edge.** This solves the known restart
+  gap, and periodic reconciliation remains a safety net. If reconciler lifecycle
+  grows more complex, consider a small pending-snapshot work queue with retry,
+  backoff, and metrics instead of a direct callback.
+- **Snapshot selector parity remains important.** When namespace or label
+  selectors become authoritative in snapshot listing, the hash must include
+  those selector inputs and `GetClusterStateForGitDest` must filter with the
+  same predicate as live event matching.
 
 ## Acceptance criteria
 
@@ -141,16 +205,16 @@ go green:
 - `TestReconcileForRuleChange_AddingSecondWatchRuleSameGVR_EmitsSnapshot`
 - `TestReconcileForRuleChange_RestartLikeBootstrap_NoSnapshotDrops`
 
-The pending e2e spec
-`PIt("should backfill pre-existing ConfigMap when WatchRule is added afterwards", ...)`
-flips from `PIt` to `It` and passes against a real k3d cluster.
+The e2e spec
+`It("should backfill pre-existing ConfigMap when WatchRule is added afterwards", Label("smoke"), ...)`
+passes against a real k3d cluster.
 
 The `EventRouter.SnapshotDeliveryDrops()` counter stays at 0 in steady state under a representative load test (creating and editing rules, restarting the controller).
 
 ## References
 
 - Trigger bug summary: [idea-cross-kind-dependency-watches.md](idea-cross-kind-dependency-watches.md) (related coordination concern around dependency-watches).
-- The early-return: [manager.go:660-664](../../internal/watch/manager.go#L660-L664).
-- The snapshot consumer that gets dropped: [event_router.go:254-263](../../internal/watch/event_router.go#L254-L263) (post-instrumentation: increments `snapshotDeliveryDrops`).
-- The GitTarget gate that skips re-snapshot on restart: [gittarget_controller.go:384](../../internal/controller/gittarget_controller.go#L384).
-- The snapshot walk itself: [GetClusterStateForGitDest at manager.go:415](../../internal/watch/manager.go#L415), [listResourcesForGVR at manager.go:604](../../internal/watch/manager.go#L604).
+- The old early-return: `ReconcileForRuleChange` in [manager.go](../../internal/watch/manager.go).
+- The snapshot consumer drop instrumentation: `RouteRepoStateEvent` and `RouteClusterStateEvent` in [event_router.go](../../internal/watch/event_router.go).
+- The GitTarget restart gate: `evaluateSnapshotGate` in [gittarget_controller.go](../../internal/controller/gittarget_controller.go).
+- The snapshot walk itself: `GetClusterStateForGitDest` and `listResourcesForGVR` in [manager.go](../../internal/watch/manager.go).

--- a/docs/future/design-snapshot-engine-evolution.md
+++ b/docs/future/design-snapshot-engine-evolution.md
@@ -1,0 +1,569 @@
+# Design: snapshot engine evolution
+
+> Status: proposed — continuation of
+> [design-rule-change-snapshot-trigger.md](design-rule-change-snapshot-trigger.md).
+> Date: 2026-05-21
+> Author context: written after a critical review of the rule-change snapshot
+> trigger implementation ([ed3a1db](#) "fix: better reconcile").
+
+This plan picks up where the rule-change snapshot trigger left off. That work
+closed the *delivery contract* gap (a snapshot now stays pending until a
+`FolderReconciler` exists). This document covers what is still wrong, what is
+still expensive, and a longer-term architecture for the watch/snapshot engine —
+including a two-tier GVK model, a dedicated tracking engine, a Redis-backed
+state layer, and a path to multi-pod HA.
+
+It is deliberately staged: Part 1 is correctness, Part 2 is cost, Part 3 is
+architecture. Parts 1 and 2 are small and should land first; Part 3 is a
+direction, not a committed design.
+
+## Background: GVR vs GVK
+
+The rest of this document — and the Part 3 architecture in particular — hinges
+on a distinction that is easy to blur. Both forms address a Kubernetes type by
+**Group / Version**, but the third component differs:
+
+| Form | Third component | Example | What it identifies |
+|------|-----------------|---------|--------------------|
+| **GVK** — GroupVersionKind | **Kind** — schema type name, singular, PascalCase | `apps/v1`, Kind `Deployment` | The *type* as written in a manifest's `apiVersion` + `kind` |
+| **GVR** — GroupVersionResource | **Resource** — plural, lowercase REST path segment | `apps/v1`, Resource `deployments` | The *HTTP endpoint* you `LIST`/`WATCH` against |
+
+The mapping between them is **not** a trivial pluralisation. It is owned by the
+cluster's RESTMapper, populated from API discovery, and it is many-to-one in
+both directions in practice:
+
+- One Kind can expose several Resources — subresources such as `pods/status`,
+  `deployments/scale`. These share a Kind but are distinct Resources.
+- The Resource (plural) is irregular often enough (`ingresses`, `endpoints`,
+  `networkpolicies`) that it must be discovered, not guessed.
+
+**Why it matters here.** Everything on the *watch path* is GVR-addressed: the
+`watch.GVR` type, the dynamic client (`dc.Resource(gvr)` requires a GVR), and
+the informer keys are all GVR. Everything on the *git representation path* is
+GVK-addressed: a file written to the repo carries `apiVersion` + `kind`, i.e. a
+GVK. The engine therefore lives on a GVR↔GVK seam, and the Tier 1 catalog in
+[Part 3.1](#31-two-tier-gvk-model) must hold **both** keys plus the mapping —
+calling it a "GVK catalog" is shorthand; its watch-facing index is GVR. Where
+this document says GVK loosely, read it as "the type", and where precision
+matters the explicit form is used.
+
+## What the Kubernetes API server can deliver
+
+Before proposing a new engine it is worth being explicit about what the API
+server actually offers a read/watch client, which of those capabilities we use
+today, and what we leave on the table. A prior document,
+[docs/design/kubernetes-api-discovery.md](../design/kubernetes-api-discovery.md),
+already covers *discoverability and verbs* — this section is the read/watch
+mechanics complement to it, and capacity tuning is covered separately in
+[docs/design/kubernetes-apf-and-inflight-tuning.md](../design/kubernetes-apf-and-inflight-tuning.md).
+
+```mermaid
+flowchart TD
+  APISERVER["kube-apiserver"]
+  APISERVER --> DISC["Discovery<br/>/api, /apis, aggregated discovery"]
+  APISERVER --> LIST["LIST<br/>collection GET"]
+  APISERVER --> WATCH["WATCH<br/>streamed deltas"]
+
+  DISC --> D1["groups, versions, resources"]
+  DISC --> D2["scope, verbs, Kind↔Resource"]
+
+  LIST --> L1["labelSelector / fieldSelector — server-side filter"]
+  LIST --> L2["limit + continue — pagination"]
+  LIST --> L3["resourceVersion=0 — served from watch cache"]
+  LIST --> L4["list carries its own resourceVersion (snapshot point)"]
+
+  WATCH --> W1["ADDED / MODIFIED / DELETED since RV"]
+  WATCH --> W2["BOOKMARK events — cheap RV checkpoint"]
+  WATCH --> W3["410 Gone — RV compacted, must re-LIST"]
+
+  classDef used fill:#1b5e20,color:#fff;
+  classDef unused fill:#5d4037,color:#fff;
+  class DISC,D1,D2,L4,WATCH,W1,W3 used;
+  class L1,L2,L3,W2 unused;
+```
+
+Green = used today, brown = available but unused.
+
+### Discovery
+
+`/api`, `/apis`, and the per-group endpoints enumerate every served Group /
+Version / Resource together with each resource's **scope** (namespaced or not),
+its **verbs** (`list`, `watch`, …), and its **Kind**. Newer clusters also serve
+*aggregated discovery* (`APIGroupDiscovery`), collapsing the whole catalog into
+one round-trip.
+
+**We use this** via `ServerPreferredResources` in
+[`FilterDiscoverableGVRs`](../../internal/watch/discovery.go#L44). The benefit
+is concrete: CRDs and `APIService`-backed (aggregated) resources are supported
+with no hardcoding — if a type is in discovery with `list`+`watch`, it is a
+candidate. This is exactly the Tier 1 catalog of [Part 3.1](#31-two-tier-gvk-model)
+in embryonic form.
+
+### LIST
+
+A collection `GET` is the bulk-read primitive. Its options matter a great deal
+for cost:
+
+- **`labelSelector` / `fieldSelector`** — server-side filtering, so the wire
+  payload is already narrowed. We do **not** use these. This is the same
+  selector-parity gap flagged in the predecessor doc: the snapshot LIST returns
+  everything of a GVR while the live path filters — they must converge.
+- **`limit` + `continue`** — pagination, bounding peak client memory. We do
+  **not** use these; `listResourcesForGVR`
+  ([manager.go:616](../../internal/watch/manager.go#L616)) passes a bare
+  `metav1.ListOptions{}`, materialising every object of a GVR at once.
+- **`resourceVersion=0`** — serve the list from the API server's in-memory
+  watch cache instead of a quorum read from etcd. Much cheaper on the
+  apiserver; bounded staleness. We do **not** set it.
+- Every list response carries its own **`resourceVersion`** — the consistent
+  snapshot point a subsequent watch resumes from. We rely on this *indirectly*
+  through informers but never read it ourselves.
+
+### WATCH
+
+A `WATCH` streams `ADDED` / `MODIFIED` / `DELETED` deltas since a given
+`resourceVersion`:
+
+- **`410 Gone`** — if that RV has aged out of the watch cache / been compacted,
+  the watch fails and the client *must* fall back to a full re-LIST. This is
+  the fundamental limit on "give me everything since an arbitrary moment" —
+  detailed in [Part 2.2](#22-resourceversion-and-watches--what-they-can-and-cannot-do).
+- **`BOOKMARK` events** (`allowWatchBookmarks=true`) — the server periodically
+  emits an object-free event that only advances the RV, letting a client
+  cheaply checkpoint progress. A controller that persists the latest bookmark
+  RV can resume a watch after a short restart *without* a full re-LIST,
+  provided it stays inside the compaction window. We do **not** use bookmarks
+  today; they become relevant to the durable-state work in
+  [Part 3.3](#33-redis-backed-state-layer).
+
+**We use WATCH** only transitively: the `dynamicinformer` factory performs
+LIST+WATCH internally for each tracked GVR. We never open a raw watch, so we
+also never see bookmarks or drive the resume logic ourselves.
+
+### What we use, and what we benefit from
+
+| Capability | Used today | Benefit / cost left on the table |
+|------------|-----------|----------------------------------|
+| Discovery (`ServerPreferredResources`) | Yes | CRD + aggregated-API support with zero hardcoding |
+| Informer LIST+WATCH per GVR | Yes | Live deltas; in-memory cache already holds every object |
+| Raw LIST in `GetClusterStateForGitDest` | Yes | **Redundant** — second full list of an already-cached GVR (Part 2.1) |
+| `limit`/`continue` pagination | No | Unbounded peak memory on large GVRs |
+| `resourceVersion=0` (watch-cache read) | No | Cheaper apiserver path for the unavoidable lists |
+| `labelSelector`/`fieldSelector` | No | Server-side narrowing; also closes the selector-parity gap |
+| Watch bookmarks | No | Cheap restart resume without full re-LIST |
+| Protobuf encoding | No (dynamic client → JSON) | Smaller payloads for built-in types |
+
+The headline: we extract real value from **discovery** and from the
+**informer** machinery, but the snapshot read path uses the *least* efficient
+shape of LIST the API server offers, and ignores every incremental-resume
+mechanism. Parts 2 and 3 are largely about closing that gap.
+
+## Where we are today
+
+The rule-change snapshot trigger added a per-GitTarget delivery contract in
+`watch.Manager`. The moving pieces:
+
+```mermaid
+flowchart TD
+  WR["WatchRule / ClusterWatchRule<br/>controllers"] -->|ReconcileForRuleChange| MGR
+  GTR["GitTargetReconciler<br/>evaluateSnapshotGate()"] -->|CreateReconciler| RM
+
+  subgraph MGR["watch.Manager"]
+    HASH["currentRuleSetSnapshots()<br/>per-target xxhash of compiled rules"]
+    subgraph S1["STATE — ruleSetSnapshotMu"]
+      LD["lastDeliveredRuleSetHash<br/>gitDestKey → hash"]
+      PD["pendingRuleSetHash<br/>gitDestKey → hash"]
+    end
+    subgraph S2["STATE — informersMu"]
+      AI["activeInformers<br/>GVR → ns → cancelFunc"]
+    end
+    subgraph S3["STATE — lastSeenMu"]
+      LS["lastSeenHash<br/>resourceKey → contentHash"]
+    end
+    EMIT["emitSnapshotForRuleChange()"]
+  end
+
+  subgraph RM["reconcile.ReconcilerManager"]
+    RECS["reconcilers map<br/>gitDestKey → *FolderReconciler"]
+    CB["onReconcilerCreated callback"]
+  end
+
+  CB -->|MaybeReplaySnapshot| MGR
+  HASH --> EMIT
+  EMIT -->|ProcessControlEvent| ER
+
+  subgraph ER["watch.EventRouter"]
+    RCS["handleRequestClusterState → live LIST"]
+    RRS["handleRequestRepoState → git ls"]
+    DROP["snapshotDeliveryDrops counter"]
+  end
+
+  ER -->|OnClusterState / OnRepoState| FR
+  FR["FolderReconciler<br/>repo-half + cluster-half<br/>→ findDifferences → WriteRequest"]
+  FR --> GIT[("git repository")]
+  FR -.->|status| GTSTATUS["GitTarget.Status<br/>SnapshotSynced cond"]
+```
+
+The full delivery sequence, including the restart-bootstrap replay path:
+
+```mermaid
+sequenceDiagram
+  participant Ctl as WatchRule controller
+  participant M as watch.Manager
+  participant RM as ReconcilerManager
+  participant ER as EventRouter
+  participant FR as FolderReconciler
+
+  Ctl->>M: ReconcileForRuleChange(ctx)
+  M->>M: currentRuleSetSnapshots() → per-target hash
+  M->>M: snapshotTargetsNeedingDelivery()
+  Note over M: pendingRuleSetHash[gitDest] = hash
+
+  alt FolderReconciler already registered
+    M->>ER: ProcessControlEvent(RequestRepoState / RequestClusterState)
+    ER->>FR: OnRepoState / OnClusterState
+    FR->>FR: reconcile() → WriteRequest
+    M->>M: markRuleSetSnapshotDelivered()
+    Note over M: lastDeliveredRuleSetHash advances
+  else No reconciler yet (restart bootstrap)
+    M-->>M: leave pending, do NOT advance lastDelivered
+    Note over RM: later — GitTargetReconciler runs
+    RM->>M: onReconcilerCreated → MaybeReplaySnapshot(gitDest)
+    M->>ER: emitSnapshotForRuleChange(...)
+    ER->>FR: OnRepoState / OnClusterState
+    M->>M: markRuleSetSnapshotDelivered()
+  end
+```
+
+Key source:
+
+- [internal/watch/manager.go](../../internal/watch/manager.go) —
+  `ReconcileForRuleChange`, `snapshotTargetsNeedingDelivery`,
+  `currentRuleSetSnapshots`, `emitSnapshotForRuleChange`, `MaybeReplaySnapshot`,
+  `GetClusterStateForGitDest`, `listResourcesForGVR`.
+- [internal/watch/event_router.go](../../internal/watch/event_router.go) —
+  `RouteClusterStateEvent`, `RouteRepoStateEvent`, `snapshotDeliveryDrops`.
+- [internal/reconcile/reconciler_manager.go](../../internal/reconcile/reconciler_manager.go) —
+  `CreateReconciler`, `SetOnReconcilerCreated`.
+- [internal/controller/gittarget_controller.go](../../internal/controller/gittarget_controller.go) —
+  `evaluateSnapshotGate`.
+
+All snapshot-trigger state (`pendingRuleSetHash`, `lastDeliveredRuleSetHash`,
+`activeInformers`, `lastSeenHash`) is **in-memory and leader-local**. The only
+persisted state is `GitTarget.Status` and git itself.
+
+## Part 1 — Correctness: finish the delivery contract
+
+The delivery contract is sound in shape but has gaps the original doc either
+under-specified or claimed as handled when they are not.
+
+### 1.1 Per-gitDest emission mutex (the real concurrency fix)
+
+The original doc's risk section says *"A per-gitDest mutex (or the existing
+`activeInformers` lock) is enough."* It was not implemented. `ruleSetSnapshotMu`
+guards **only the hash maps**. The actual emission — `emitSnapshotForRuleChange`
+→ `reconciler.ResetState()` → cluster LIST → routing — runs with no lock.
+
+A 30 s periodic `ReconcileForRuleChange` and a `MaybeReplaySnapshot` (fired
+synchronously from `CreateReconciler`) can run concurrently for the *same*
+gitDest. Both call `ResetState()`
+([folder_reconciler.go:111](../../internal/reconcile/folder_reconciler.go#L111));
+one can wipe a half-arrived state pair from the other, so `reconcile()` either
+never fires or fires on mismatched halves.
+
+**Fix:** a per-gitDest mutex held across the whole emit (reset → emit repo →
+emit cluster → mark delivered). A `map[string]*sync.Mutex` keyed by
+`gitDest.Key()`, or a single emission mutex if contention is acceptable at MVP
+scale.
+
+### 1.2 Stop using `context.Background()` in `MaybeReplaySnapshot`
+
+`MaybeReplaySnapshot`
+([manager.go](../../internal/watch/manager.go) — see `MaybeReplaySnapshot`)
+runs a full cluster-wide LIST with no deadline, **synchronously inside the
+GitTarget reconcile loop** (`CreateReconciler` → `onReconcilerCreated`
+callback). A slow API server stalls a controller-runtime reconcile worker.
+
+**Fix:** thread the reconcile `ctx` through the callback, or dispatch the
+replay onto the Manager's own goroutine with a bounded context.
+
+### 1.3 Mark delivered only on confirmed receipt
+
+`emitSnapshotForRuleChange` calls `markRuleSetSnapshotDelivered` immediately
+after `ProcessControlEvent` returns `nil`. But `RouteClusterStateEvent` /
+`RouteRepoStateEvent` return `nil` *even when they drop the event* — they only
+bump `snapshotDeliveryDrops`
+([event_router.go:260-281](../../internal/watch/event_router.go#L260-L281)).
+The `GetReconciler` existence check just above guards this today, but it is
+TOCTOU: a reconciler deleted between check and route advances the hash on a
+dropped snapshot → permanent silent loss until the next rule change.
+
+**Fix:** have the route functions return a `delivered bool`; advance
+`lastDeliveredRuleSetHash` only when delivery is confirmed.
+
+### 1.4 Make `force` per-target, not global
+
+`snapshotTargetsNeedingDelivery(len(added) > 0 || len(removed) > 0)`
+([manager.go:695](../../internal/watch/manager.go#L695)) passes a **global**
+boolean. Any GVR add/remove anywhere forces a snapshot for *every* GitTarget,
+including unaffected ones. The original doc claims the hash version *"pays the
+same cost only when the hash changes"* — true only on the non-force path.
+
+**Fix:** drop `force` entirely. A genuine GVR change already changes the
+affected target's rule hash, so the hash alone is sufficient and naturally
+per-target. This removes a whole-cluster re-list amplification on CRD install.
+
+### 1.5 Doc hygiene
+
+[design-rule-change-snapshot-trigger.md](design-rule-change-snapshot-trigger.md)
+still cites `manager.go:660` for the old early-return; it is now line 696.
+Fix the stale reference since the doc is marked "implemented".
+
+## Part 2 — Cost: stop paying for the cluster twice
+
+This addresses the open worry: *will this concept eat too many resources in big
+clusters with many resources?*
+
+### 2.1 Serve the snapshot from the informer cache
+
+`GetClusterStateForGitDest` → `listResourcesForGVR`
+([manager.go:616](../../internal/watch/manager.go#L616)) does a fresh
+`dc.Resource(gvr).List(...)` — a **second full cluster LIST** — for a GVR whose
+informer is *already synced and already holding every object in its in-memory
+indexer*. We pay for the list twice: once for `WaitForCacheSync`
+([manager.go:1165](../../internal/watch/manager.go#L1165)), once for the
+snapshot.
+
+**Fix:** read the snapshot from `informer.GetIndexer().List()` instead of a
+live API LIST. The snapshot becomes essentially free — no API round-trip, no
+second in-memory copy. The reconcile flow already guarantees the informer is
+synced before emission, so correctness holds.
+
+This is the single highest-leverage change for big-cluster cost.
+
+### 2.2 resourceVersion and watches — what they can and cannot do
+
+The idea of "request changesets since a moment" using `resourceVersion` is
+exactly what informers already do (LIST, remember RV, WATCH from that RV). Two
+hard limits stop it from being a primary snapshot mechanism:
+
+- **Watch history is bounded.** The API server retains only recent watch events
+  (etcd compaction + watch-cache window — minutes, not hours). A watch from an
+  aged-out RV returns `410 Gone`, forcing a full re-LIST. "Everything changed
+  since the last restart" is therefore not reliable across any restart longer
+  than the compaction window.
+- **`resourceVersion` is opaque.** It is not an ordered comparable integer in
+  the API contract. You cannot do `if obj.RV > lastSyncedRV` in your own diff
+  logic; you can only hand it back to the API server.
+
+Where per-object RV *does* help: as a **persisted dedup key**. Storing the
+last-synced RV per resource lets a re-LIST skip the sanitize + diff for any
+object whose RV is unchanged — it does not save the LIST, but it saves CPU when
+the diff is the bottleneck. This is the natural successor to the in-memory
+`lastSeenHash` map.
+
+### 2.3 Bound the unavoidable LISTs
+
+For the LISTs that remain (initial sync, post-`410` re-sync):
+
+- **Pagination** — `ListOptions{Limit: N, Continue: ...}` bounds peak memory.
+  `listResourcesForGVR` currently passes a bare `metav1.ListOptions{}`.
+- **`ResourceVersion: "0"`** — serves the LIST from the API server watch cache
+  rather than a quorum etcd read; much cheaper on the apiserver, with bounded
+  staleness that is acceptable here.
+
+```mermaid
+flowchart LR
+  subgraph Now["Today — double list"]
+    I1[informer LIST+WATCH] --> C1[(informer cache)]
+    SNAP1[GetClusterStateForGitDest] --> L2[second live LIST]
+  end
+  subgraph Next["Proposed — single list"]
+    I2[informer LIST+WATCH] --> C2[(informer cache)]
+    SNAP2[GetClusterStateForGitDest] --> C2
+  end
+```
+
+## Part 3 — Architecture: a two-tier GVK model and a tracking engine
+
+This part responds to the broader question: *should there be an abstraction
+over all GVKs (split per namespace), with a catalog of all available GVKs and a
+second, narrower set of tracked GVKs — and should tracking/storing move into a
+separate process and a Redis layer, in preparation for HA?*
+
+Short answer: yes to the two-tier model and the dedicated engine — they
+formalise concepts that are already implicit in the code. Redis and multi-pod
+HA are a real direction but should come last and be entered with eyes open.
+
+### 3.1 Two-tier GVK model
+
+The code already computes two GVK sets but does not name them as a model:
+
+- **Requested** GVRs — `ComputeRequestedGVRs`
+  ([gvr.go:53](../../internal/watch/gvr.go#L53)) — derived from rules.
+- **Discoverable** GVRs — `FilterDiscoverableGVRs`
+  ([discovery.go:44](../../internal/watch/discovery.go#L44)) — filtered against
+  the discovery API.
+
+Promote this into an explicit two-tier registry:
+
+- **Tier 1 — GVK Catalog.** Every GVK the cluster exposes, refreshed
+  periodically from the discovery API, annotated with scope (namespaced vs
+  cluster), served-ness, and CRD lifecycle. This is cluster-global and
+  rule-independent.
+- **Tier 2 — Tracked Set.** The subset the rules actually select, keyed by
+  `(GVK, namespace)` so namespace-scoped informers are first-class rather than
+  a special case threaded through `getNamespacesForGVR`. Each tracked entry
+  carries its delivery state: rule-set hash, last snapshot RV, owning shard.
+
+```mermaid
+flowchart TD
+  DISC["Discovery API"] -->|periodic refresh| CAT
+  CAT["Tier 1 — GVK Catalog<br/>all served GVKs + scope + CRD lifecycle"]
+  RULES["RuleStore<br/>compiled WatchRule / ClusterWatchRule"] --> SEL
+  CAT --> SEL
+  SEL["selection: rules ∩ catalog"]
+  SEL --> TRACK
+  TRACK["Tier 2 — Tracked Set<br/>key = (GVK, namespace)<br/>per-entry: ruleSetHash, lastSnapshotRV, shard"]
+  TRACK --> ENG["Tracking Engine<br/>owns informer lifecycle + snapshot store"]
+```
+
+Benefits: CRD-availability retry logic
+(`updateUnavailableGVRTracking` and friends) becomes a property of Tier 1
+rather than ad-hoc maps; the `(GVK, namespace)` key removes the cluster-wide vs
+namespaced branching that currently runs through `compareGVRs`,
+`getNamespacesForGVR`, and `collectInformersToStart`.
+
+### 3.2 A dedicated tracking engine
+
+Today `watch.Manager` is a controller-runtime `Runnable` that does discovery,
+informer lifecycle, dedup, snapshot emission, and the delivery contract — all
+in one object, all on the leader. Splitting the *tracking/storing* concern into
+its own component (not necessarily its own OS process — a clearly-bounded
+internal service with its own goroutine and queue) gives:
+
+- A single owner for informer lifecycle and the snapshot store.
+- A natural seam to make snapshot emission a queued, retried, observable
+  operation instead of inline calls inside `ReconcileForRuleChange`. The
+  original doc's "future improvements" already names this: *"a small
+  pending-snapshot work queue with retry, backoff, and metrics."*
+- A boundary that can later be moved across a process or pod boundary without
+  re-plumbing the controllers.
+
+### 3.3 Redis-backed state layer
+
+Everything fragile in Part 1 is fragile because it is in-memory and
+leader-local. A shared store would hold:
+
+- `pendingRuleSetHash` / `lastDeliveredRuleSetHash` — survive restart and
+  failover, so a pending snapshot is not silently lost on leader change.
+- The per-resource RV / content-hash index (today `lastSeenHash`) — dedup
+  survives restart and can be shared across pods.
+- The Tier 2 Tracked Set and shard ownership leases.
+
+Redis is a reasonable first choice (leases, hashes, pub/sub for cross-pod
+notification). **But be honest about the cost:** it adds an external dependency
+and a new failure mode to a project whose code still says *"Single-pod MVP"*.
+An intermediate step worth considering first: persist the delivery contract
+into `GitTarget.Status` (already durable, already reconciled) and keep only the
+high-churn dedup index in memory. That removes the worst silent-loss case
+without a new dependency.
+
+### 3.4 Multi-pod / HA
+
+Today `Manager.NeedLeaderElection()` returns `true`
+([manager.go:207](../../internal/watch/manager.go#L207)) — strictly
+single-active. Two evolution paths:
+
+```mermaid
+flowchart TD
+  subgraph AP["Option A — active / passive"]
+    L1["leader pod: all informers + snapshots"]
+    L2["standby pod: idle, reads shared state"]
+    L1 -.->|failover, state in Redis| L2
+  end
+  subgraph SH["Option B — sharded active / active"]
+    S1["pod 1: shard A of (GVK,ns)"]
+    S2["pod 2: shard B of (GVK,ns)"]
+    S3["pod 3: shard C of (GVK,ns)"]
+    LEASE["Redis leases — shard ownership"]
+    S1 --- LEASE
+    S2 --- LEASE
+    S3 --- LEASE
+  end
+```
+
+- **Option A — active/passive with fast failover.** Keep single-active, but
+  persist the delivery contract so the new leader resumes pending snapshots
+  instead of dropping them. Low complexity, no informer fan-out change. This is
+  the recommended next HA step.
+- **Option B — sharded active/active.** Partition the Tier 2 Tracked Set across
+  pods by `(GVK, namespace)`, each shard leased via Redis. This is true
+  horizontal scale but the hard part is that rules map GitTargets to GVKs
+  many-to-many — a snapshot for one GitTarget may need GVKs owned by several
+  shards. That cross-shard fan-in needs its own design and should not be
+  attempted before Options A and the two-tier model are in place.
+
+**Recommendation:** treat Option B as a stated direction, not a near-term
+commitment. The selector-parity hazard already flagged in the prior doc must
+also be resolved before sharding, or different shards will diff against
+different predicates.
+
+## Staging and acceptance
+
+```mermaid
+flowchart LR
+  P1["Part 1<br/>correctness fixes"] --> P2["Part 2<br/>informer-cache snapshot"]
+  P2 --> P3a["Part 3a<br/>two-tier GVK model"]
+  P3a --> P3b["Part 3b<br/>tracking engine"]
+  P3b --> P3c["Part 3c<br/>durable state / Redis"]
+  P3c --> P3d["Part 3d<br/>HA: active/passive → sharded"]
+```
+
+- **Part 1** — small, self-contained, no API change. Acceptance: the four
+  existing tests in
+  [rule_change_snapshot_test.go](../../internal/watch/rule_change_snapshot_test.go)
+  still pass, plus a new test that runs a periodic reconcile and a
+  `MaybeReplaySnapshot` concurrently for one gitDest and asserts exactly one
+  coherent reconcile.
+- **Part 2** — no API change. Acceptance: `GetClusterStateForGitDest` issues
+  zero live LIST calls for an already-synced GVR; a load test over a large
+  synthetic cluster shows bounded memory.
+- **Part 3** — each sub-stage is its own design doc. The two-tier model
+  (3a) and tracking engine (3b) are internal refactors with no CRD change.
+  Durable state (3c) and HA (3d) change operational surface and need their own
+  acceptance criteria, including a `SnapshotDeliveryDrops()`-equivalent staying
+  at zero across a simulated failover.
+
+## Non-goals
+
+- No CRD changes in Parts 1 and 2.
+- No new external dependency before Part 3c, and only after the
+  `GitTarget.Status`-only intermediate step is evaluated.
+- No sharded active/active before the two-tier model, the tracking engine, and
+  selector parity all land.
+
+## References
+
+- Predecessor:
+  [design-rule-change-snapshot-trigger.md](design-rule-change-snapshot-trigger.md).
+- API discovery background (discoverability and verbs):
+  [docs/design/kubernetes-api-discovery.md](../design/kubernetes-api-discovery.md).
+- API server capacity tuning:
+  [docs/design/kubernetes-apf-and-inflight-tuning.md](../design/kubernetes-apf-and-inflight-tuning.md).
+- Related coordination concern:
+  [idea-cross-kind-dependency-watches.md](idea-cross-kind-dependency-watches.md).
+- Snapshot walk and double-list:
+  [GetClusterStateForGitDest / listResourcesForGVR](../../internal/watch/manager.go).
+- Delivery contract state:
+  `snapshotTargetsNeedingDelivery`, `markRuleSetSnapshotDelivered`,
+  `MaybeReplaySnapshot` in [manager.go](../../internal/watch/manager.go).
+- Drop instrumentation:
+  `RouteRepoStateEvent` / `RouteClusterStateEvent` in
+  [event_router.go](../../internal/watch/event_router.go).
+- GVK discovery: `ComputeRequestedGVRs`
+  ([gvr.go](../../internal/watch/gvr.go)),
+  `FilterDiscoverableGVRs`
+  ([discovery.go](../../internal/watch/discovery.go)).
+</content>
+</invoke>

--- a/docs/future/idea-cross-kind-dependency-watches.md
+++ b/docs/future/idea-cross-kind-dependency-watches.md
@@ -1,0 +1,182 @@
+# Idea: cross-kind dependency watches as a first-class concern
+
+> Status: idea — captured after issue #145.
+> Date: 2026-05-20
+> Triggering bug: [#145](https://github.com/ConfigButler/gitops-reverser/issues/145) — GitTarget / ClusterWatchRule / WatchRule did not react to their referenced dependency appearing, recovering only on the periodic `RequeueShortInterval` (~2 min).
+
+## The bug class in one sentence
+
+A controller whose `Reconcile` reads a sibling kind by name but whose `SetupWithManager`
+does not `Watches(...)` that kind will treat "dependency arrived" as an event it cannot see;
+recovery time is bounded by the controller's `RequeueAfter`, not by the cluster's actual
+state-change latency.
+
+Issue #145 was the third instance of this pattern in this repo (`GitTarget → GitProvider`,
+`ClusterWatchRule → GitTarget`, `WatchRule → GitTarget`) and is the kind of thing every
+operator team rediscovers once per project. ConfigButler — both the operator and the
+audit/lint surface around it — is well placed to turn this into a solved problem instead
+of a tribal-knowledge one.
+
+## Why per-pair plumbing is the wrong layer to keep iterating on
+
+The fix for #145 was three near-identical `Watches(...)` calls plus three near-identical
+map functions:
+
+```go
+// gitProviderToGitTargets, gitTargetToClusterWatchRules, gitTargetToWatchRules,
+// gitProviderToClusterWatchRules, gitProviderToWatchRules — same shape.
+List dependents in the dependency's scope.
+Filter by spec.<refField>.name (and namespace, for cross-namespace refs).
+Return as []reconcile.Request.
+```
+
+Every new reference adds one of these. Forgetting one looks identical to the bug we just
+fixed: dependent gets stuck on `*NotFound`, status self-heals on the periodic requeue, no
+loud failure. Reviewers don't catch it because the dependent's `Reconcile` *does* read the
+dependency — the missing piece is in the wiring file three hundred lines away.
+
+## The ladder
+
+Four options, weakest to strongest. Not mutually exclusive — (2) and (4) are the
+recommended pair.
+
+### 1. Convention + generator (cheap, partial)
+
+Document the rule: "for every `*Ref` field in a CRD spec, the controller must `Watches`
+the referenced kind." Optionally emit map functions from kubebuilder markers:
+
+```go
+// +configbutler:dependsOn=GitProvider,refField=spec.providerRef.name,namespaceField=metadata.namespace
+type GitTargetSpec struct { ... }
+```
+
+Cheap to ship; still requires authors to remember the marker. Doesn't help downstream
+operators that aren't ours. Skip on its own.
+
+### 2. Library helper — `WatchesRef[T]` (recommended, near-term)
+
+A small wrapper around `Watches(...) + handler.EnqueueRequestsFromMapFunc(...)` that
+takes a typed extractor from the dependent to the dependency it points at, and indexes
+candidates by that reference. One line per dependency edge replaces the current 10–30
+lines per pair.
+
+Sketch:
+
+```go
+func WatchesRef[Dep client.Object, Dependent client.Object](
+    b *builder.Builder,
+    deps DependentLister[Dependent],
+    refOf func(Dependent) types.NamespacedName,
+    scope ListScope, // namespaced or cluster-wide
+) *builder.Builder
+```
+
+Caller (replacing today's `gitProviderToGitTargets`):
+
+```go
+WatchesRef[*GitProvider, *GitTarget](
+    b, gtList,
+    func(t *GitTarget) types.NamespacedName {
+        return types.NamespacedName{Name: t.Spec.ProviderRef.Name, Namespace: t.Namespace}
+    },
+    ListScope{InNamespaceOfDependency: true},
+)
+```
+
+What this buys:
+
+- Eliminates copy-paste map functions. The five we just shipped collapse to five
+  one-liners.
+- Refs become greppable: every cross-kind dependency in the codebase is a `WatchesRef[...]`
+  call site. New ones show up in review.
+- A simple unit-test pattern carries over (the existing
+  [dependency_watches_test.go](../../internal/controller/dependency_watches_test.go)
+  pattern works unchanged — the helper is just where the loop body lives).
+
+What it doesn't buy: downstream operator authors don't see this unless they import the
+ConfigButler library, which most won't.
+
+### 3. Status-driven auto-wiring (the structural answer)
+
+The signal is already in the bug: every dependent emitted `Ready=False,
+reason=ProviderNotFound, message="Referenced GitProvider 'gitops-reverser/cozystack-example'
+not found"`. The dependency is named in the status. A generic "unmet-dependency reconciler"
+can:
+
+1. Watch every CRD in the controller's scope for `Ready=True` transitions.
+2. For every dependent whose status carries a structured `Unmet` reference matching the
+   object that just went Ready, enqueue it.
+
+To make this work we need to upgrade the convention beyond a free-text `message` field.
+Two options:
+
+- **Annotation-level**: dependents carry `configbutler.ai/unmet: configbutler.ai/v1alpha1/GitProvider/gitops-reverser/cozystack-example` while their dependency is missing; cleared on Ready.
+- **Status-level** (preferred): a `status.unmetReferences []TypedObjectReference` field on every CRD that participates. Same idea, schema-validated, no annotation churn.
+
+This is the same shape as kstatus's reason taxonomy and Crossplane's composition references;
+it scales because the per-controller code is "fill in `unmetReferences`", not "wire up
+Watches per kind." The auto-wiring loop is written once.
+
+Cost: a CRD field convention and a small generic controller. Worth it once we have ≥ 4–5
+cross-kind references, or once external CRDs (Flux's `GitRepository`, third-party providers)
+need to participate without us editing them.
+
+### 4. The auditor angle (recommended, where ConfigButler differentiates)
+
+Static analysis can detect this bug class today, against any operator's repo, without
+asking the author to adopt a library.
+
+Detection rule, informally:
+
+> For each controller, intersect the set of kinds read in `Reconcile` (via `r.Get`,
+> `r.List`) with the set of kinds in `For(...)` / `Owns(...)` / `Watches(...)` calls in
+> `SetupWithManager`. Any kind in the first set but not the second is a candidate
+> "stuck dependent" — flag with the controller's `RequeueAfter` as the expected recovery
+> time.
+
+This is tractable with `go/ssa` or even AST + a small whitelist of known controller-runtime
+call signatures. Cluster-api, Crossplane, and Flux's own controllers all have past
+instances of exactly this bug; an auditor that catches it on first install would land hard.
+
+Concrete deliverable: an `auditor check stuck-dependents` rule in the ConfigButler audit
+tool, with the exit message naming the missing `Watches`, the kind, and the
+`RequeueAfter`-bounded delay the operator will see in production.
+
+## Recommendation
+
+Ship **(2)** as a small internal helper this quarter — it's a refactor of code we already
+have, removes the boilerplate, and makes future refs single-line. Treat **(4)** as the
+product opportunity: the value to external operator authors is high, the implementation
+is one focused analyzer, and it's the rare static check that turns an invisible operator
+bug into a CI failure. **(3)** is the durable answer if/when the cross-kind reference
+graph grows past what `WatchesRef` is pleasant for, or once non-ConfigButler CRDs need to
+participate; defer until that pressure is real.
+
+## Non-goals
+
+- Removing the periodic `RequeueShortInterval`. It stays as a safety net regardless of
+  which option above is taken — Watches can be missed (informer restarts, RBAC gaps).
+- A generic "ref resolver" that hides the per-controller validation. Status messages
+  still need to be precise; only the *enqueue* path is mechanizable.
+
+## Risk / open questions
+
+- **`WatchesRef` and generics**: controller-runtime's `builder.Builder.Watches` is not
+  generic-friendly; the helper likely ends up taking a non-generic `client.Object` plus
+  a type-asserting extractor. Acceptable; the call site is still one line.
+- **Status-driven autowiring vs. RBAC**: cluster-wide watch of every CRD is a privilege
+  ask. The generic controller would need to either be scoped or rely on dynamic informers
+  per-CRD; both have ergonomics cost. This is why (3) is deferred.
+- **Auditor false positives**: a controller may legitimately read a sibling kind only on
+  an out-of-band path (e.g. webhook validation) and not need a watch. The check needs a
+  way to silence those — likely a `// configbutler:no-watch-required` comment marker.
+
+## References
+
+- The fix for the triggering bug:
+  [`gittarget_controller.go:903`](../../internal/controller/gittarget_controller.go#L903),
+  [`clusterwatchrule_controller.go:308`](../../internal/controller/clusterwatchrule_controller.go#L308),
+  [`watchrule_controller.go:328`](../../internal/controller/watchrule_controller.go#L328).
+- The unit-test pattern that survives the (2) refactor:
+  [`dependency_watches_test.go`](../../internal/controller/dependency_watches_test.go).
+- Periodic-requeue safety net: [`constants.go`](../../internal/controller/constants.go) (`RequeueShortInterval`).

--- a/docs/git-author.md
+++ b/docs/git-author.md
@@ -32,7 +32,7 @@ claims into that map. When it does, `gitops-reverser` still ignores them:
 We would like commits to read:
 
 ```text
-Author: Simon Koudijs <simon@koudijs.dev>
+Author: Simon Koudijs <something@configbutler.ai>
 ```
 
 ## Requested change
@@ -45,7 +45,7 @@ To start simple, the key names are **hardcoded** rather than configurable:
 
 ```text
 configbutler.ai/claims/display-name    e.g. "Simon Koudijs"
-configbutler.ai/claims/email           e.g. "simon@koudijs.dev"
+configbutler.ai/claims/email           e.g. "something@configbutler.ai"
 ```
 
 These match the extras published by our reference kube-apiserver structured
@@ -156,7 +156,7 @@ and `email` → `configbutler.ai/claims/email`, a commit made by an OIDC user
 should read:
 
 ```text
-Author: Simon Koudijs <simon@koudijs.dev>
+Author: Simon Koudijs <something@configbutler.ai>
 ```
 
 A cluster whose API server publishes neither extra should produce today's

--- a/docs/git-author.md
+++ b/docs/git-author.md
@@ -1,0 +1,165 @@
+# gitops-reverser improvement plan
+
+## Title
+
+Use OIDC display name and email from audit `user.extra` for the git commit author
+
+## Body
+
+`gitops-reverser` attributes each commit to the user that made the cluster
+change. Today the author name and email are both derived from a single string —
+the Kubernetes username — which produces poor results for OIDC users.
+
+With an OIDC-authenticated user, the Kubernetes username is the issuer-prefixed
+identity, e.g. `https://keycloak.cozy.z65.nl/realms/cozy#simon`. The resulting
+commit is:
+
+```text
+Author: https://keycloak.cozy.z65.nl/realms/cozy#simon <httpskeycloak.cozy.z65.nlrealmscozysimon@noreply.cluster.local>
+```
+
+The email is mangled because [`ConstructSafeEmail`](../internal/git/commit.go)
+strips every character outside `[a-z0-9.-]` from the username and appends
+`@noreply.cluster.local`. The name is the raw username.
+
+The real display name and email *are* available — they just are not used.
+A Kubernetes audit event carries `Event.User.Extra` (`map[string]ExtraValue`,
+where `ExtraValue` is `[]string`), and the API server can be configured (via
+structured authentication configuration) to map the OIDC `name` and `email`
+claims into that map. When it does, `gitops-reverser` still ignores them:
+`resolveUserInfo` reads only `event.User.Username`.
+
+We would like commits to read:
+
+```text
+Author: Simon Koudijs <simon@koudijs.dev>
+```
+
+## Requested change
+
+Let `gitops-reverser` source the git author **display name** and **email** from
+two fixed keys in the audit event's `user.extra` map, falling back to the
+current behaviour when those keys are absent or carry an unusable value.
+
+To start simple, the key names are **hardcoded** rather than configurable:
+
+```text
+configbutler.ai/claims/display-name    e.g. "Simon Koudijs"
+configbutler.ai/claims/email           e.g. "simon@koudijs.dev"
+```
+
+These match the extras published by our reference kube-apiserver structured
+authentication configuration. Making the key names configurable is a possible
+later enhancement — deferred until a second cluster actually needs different
+names.
+
+Behaviour:
+
+- If the display-name extra is present and its value is usable, use it for the
+  git author `Name`; otherwise use `Username` as today.
+- If the email extra is present and its value is usable, use it for the git
+  author `Email`; otherwise fall back to `ConstructSafeEmail(Username)` as today.
+- When neither extra is present, behaviour is byte-for-byte unchanged. This
+  keeps the change fully backward compatible.
+
+### Identity selection (impersonation)
+
+`resolveUserInfo` already prefers the impersonated user over the authenticated
+user when impersonation is in play. That behaviour does not change. The new code
+reads `Extra` from **the same user that wins** — if the impersonated user is
+used, read `ImpersonatedUser.Extra`; otherwise read `User.Extra`. Display name,
+email, and username always describe one consistent identity.
+
+### Keeping it safe
+
+`user.extra` values originate from an external identity provider, so they are
+untrusted input being placed into a git signature header. Two guards keep this
+safe:
+
+- **Multi-value handling.** `ExtraValue` is a `[]string`. Treat an empty slice
+  as absent; use the first element otherwise.
+- **Value validation before use.** A name or email containing a newline or
+  control character would corrupt the git commit object. Before using an extra
+  value:
+  - *Display name*: reject it if it contains control characters or newlines, or
+    is empty/whitespace after trimming. On rejection, fall back to `Username`.
+  - *Email*: accept it only if it matches the same valid-email regex already
+    used inside `ConstructSafeEmail`. On rejection, fall back to
+    `ConstructSafeEmail(Username)`.
+
+Both fallbacks are exactly today's behaviour, so a malformed claim degrades
+gracefully rather than producing a broken commit.
+
+`email-verified` is also published as a separate extra
+(`configbutler.ai/claims/email-verified`), so `gitops-reverser` could later
+decline to use an unverified email. That is a possible enhancement, not part of
+this change.
+
+## Implementation pointers
+
+The change is localised to the `git` and `queue` packages. Module
+`github.com/ConfigButler/gitops-reverser`, observed at release `0.24.0`:
+
+- **Hardcoded keys.** Define the two extra-key constants near `resolveUserInfo`
+  in [`internal/queue/redis_audit_consumer.go`](../internal/queue/redis_audit_consumer.go),
+  e.g. `displayNameExtraKey` and `emailExtraKey`.
+- **`internal/git/types.go`** — extend `UserInfo` with optional
+  `DisplayName string` and `Email string` fields. Adding fields is additive; the
+  ~20 existing `UserInfo{Username: ...}` test constructions are unaffected.
+- **`internal/queue/redis_audit_consumer.go`** — `resolveUserInfo()` currently
+  returns `git.UserInfo{Username: username}`. After selecting the effective
+  user (authenticated or impersonated), read that user's `Extra` at the two
+  hardcoded keys, apply the multi-value and validation rules above, and populate
+  the new `DisplayName` / `Email` fields. Leaving a field empty signals "fall
+  back".
+- **`internal/git/pending_writes.go`** — `PendingWrite.Author()` returns a bare
+  username string. Add an accessor that surfaces the full author identity
+  (e.g. `AuthorUserInfo()` returning the `UserInfo` of `Events[0]`) so the
+  display name and email reach commit time. Prefer this over a parallel
+  `AuthorSignature()` helper.
+- **`internal/git/commit.go`** — `commitOptionsFor()` builds the
+  `object.Signature`. Use `UserInfo.DisplayName` for `Name` and `UserInfo.Email`
+  for `Email` when present; keep `Username` + `ConstructSafeEmail` as the
+  fallback. Validation can live here, next to `ConstructSafeEmail`, so the git
+  package owns "what is safe in a signature".
+- **`internal/git/open_window.go`** — commit-window coalescing keys on
+  `Author` (the username) at `open_window.go:50`/`open_window.go:61`. Keep that
+  key as the username — it is the stable identity used for coalescing and for
+  the grouped commit *message* `{{.Author}}`. Only the commit's `Author:`
+  signature gains the display name; the message text is unchanged.
+
+### Scope note
+
+Author identity flows through per-event and grouped (commit-window) commits.
+Atomic / reconcile-driven commits set the operator as the author already
+(`commitOptionsFor` returns the committer when `PendingWrite.Author()` is empty)
+and are intentionally left unchanged by this work.
+
+## Why this matters
+
+`gitops-reverser` turns cluster changes into a git history. A git history is
+only useful for audit and `git blame` if the author is a real, recognisable
+identity. With OIDC — which is the recommended way to authenticate real humans
+to a cluster — the current output is an unreadable URL fragment and a
+non-deliverable email address.
+
+The fix does not require `gitops-reverser` to understand OIDC, talk to an
+identity provider, or hold any credentials. It only needs to read two extra
+fields that the Kubernetes audit event already delivers. The API-server side
+(mapping `name`/`email` claims into `user.extra`) is standard, supported
+Kubernetes configuration and is the operator's responsibility.
+
+## Verification
+
+With the API server configured to map `name` → `configbutler.ai/claims/display-name`
+and `email` → `configbutler.ai/claims/email`, a commit made by an OIDC user
+should read:
+
+```text
+Author: Simon Koudijs <simon@koudijs.dev>
+```
+
+A cluster whose API server publishes neither extra should produce today's
+output for an identical change, confirming backward compatibility. A claim
+carrying a malformed value (newline in the name, non-email string in the email)
+should also fall back to today's output rather than producing a broken commit.

--- a/docs/interpreting-metrics.md
+++ b/docs/interpreting-metrics.md
@@ -1,0 +1,253 @@
+# Interpreting GitOps Reverser Metrics
+
+> Last updated: May 2026
+
+This is the operator's field guide to the metrics GitOps Reverser exports. It explains how to
+read each metric family and gives copy-pasteable PromQL for the questions operators actually
+ask.
+
+It is a living document. New metrics should arrive here with at least one example query — a
+metric nobody knows how to read is not observable.
+
+---
+
+## Where metrics come from
+
+GitOps Reverser exports Prometheus-format metrics via the controller-runtime metrics server.
+The bind address is `servers.metrics.bindAddress` (default `:8080`); metrics are served at
+`/metrics`.
+
+All metric names are prefixed `gitopsreverser_`. Throughout this document the prefix is
+omitted in prose but kept in queries.
+
+Three instrument shapes appear:
+
+| Shape | Suffix | How to read it |
+| --- | --- | --- |
+| **Counter** | `_total` | Monotonic. Always wrap in `rate(...[5m])` or `increase(...[1h])` — the raw value is meaningless. |
+| **Histogram** | `_seconds` | Exposes `_bucket`, `_sum`, `_count`. Use `histogram_quantile()` for percentiles; `_count` is a free counter of observations. |
+| **Gauge** | (none) | Instantaneous value; read directly. |
+
+### Reading a histogram
+
+A histogram named `foo_seconds` produces three series:
+
+- `foo_seconds_bucket{le="..."}` — cumulative count per bucket boundary
+- `foo_seconds_count` — total number of observations (use it like a counter)
+- `foo_seconds_sum` — sum of all observed values
+
+Percentile:
+
+```promql
+histogram_quantile(0.95, sum by (le) (rate(gitopsreverser_foo_seconds_bucket[5m])))
+```
+
+Mean:
+
+```promql
+rate(gitopsreverser_foo_seconds_sum[5m]) / rate(gitopsreverser_foo_seconds_count[5m])
+```
+
+---
+
+## Audit join pipeline
+
+This is the most timing-sensitive subsystem, so it gets the most coverage. Background:
+[architecture.md → Audit Ingestion Pipeline](architecture.md#audit-ingestion-pipeline).
+
+The pipeline joins two event sources per `auditID`: the **official** kube-apiserver audit event
+(authoritative for *who/when*) and an **additional** body contribution from a proxy
+(authoritative for *what*, on aggregated-API paths). They race. The healthy case is the
+additional body arriving first and parking; when the official wins the race it waits up to
+`--audit-event-body-wait` (default `500ms`) for the body before dropping.
+
+### The metrics
+
+| Metric | Type | Labels |
+| --- | --- | --- |
+| `audit_events_received_total` | counter | `source`, `gvr`, `action`, `user` |
+| `audit_event_quality_total` | counter | `source`, `quality`, `gvr`, `action` |
+| `audit_join_parked_total` | counter | `parked_kind` |
+| `audit_join_emitted_total` | counter | `source`, `result` (`as_is`, `merged`) |
+| `audit_join_duplicate_dropped_total` | counter | `reason` |
+| `audit_shallow_dropped_total` | counter | `gvr`, `action` |
+| `audit_join_body_late_total` | counter | `gvr`, `action` |
+| `audit_join_skew_seconds` | histogram | `arrival` (`body_first`/`official_first`), `outcome` (`merged`/`timed_out`) |
+| `audit_official_gate_wait_seconds` | histogram | — |
+
+`audit_join_skew_seconds` is the centerpiece for timing health. Every official↔additional pair
+produces one observation:
+
+- **`arrival="body_first"`** — the additional body was already parked when the official arrived.
+  The value is the proxy's *lead time*: how long the body sat parked. Always `outcome="merged"`.
+- **`arrival="official_first"`** — the official arrived first and waited on the canonical gate.
+  The value is the wait duration. `outcome="merged"` if the body arrived in time,
+  `outcome="timed_out"` if the grace period expired (that event is also counted in
+  `audit_shallow_dropped_total`).
+
+### Query cookbook
+
+**Is the join working at all?** Rate of canonical emissions, split by how they resolved:
+
+```promql
+sum by (result) (rate(gitopsreverser_audit_join_emitted_total[5m]))
+```
+
+`result="merged"` means an official was completed by a parked/awaited body; `as_is` means the
+official already carried its own body.
+
+**How often does the race go the "wrong" way?** Fraction of joins where the official arrived
+before its body:
+
+```promql
+sum(rate(gitopsreverser_audit_join_skew_seconds_count{arrival="official_first"}[5m]))
+/
+sum(rate(gitopsreverser_audit_join_skew_seconds_count[5m]))
+```
+
+Near `0` is healthy. Climbing toward `1` means the proxy is consistently behind the apiserver.
+
+**Is `--audit-event-body-wait=500ms` enough?** p95 of the time officials spend waiting:
+
+```promql
+histogram_quantile(0.95,
+  sum by (le) (rate(gitopsreverser_audit_join_skew_seconds_bucket{arrival="official_first"}[5m])))
+```
+
+If this creeps toward the configured `bodyWait`, raise the flag **before** drops start — this
+is the early-warning signal. If it sits near zero, the wait budget has plenty of headroom.
+
+**Did waiting actually pay off?** Merged-after-wait vs timed-out:
+
+```promql
+sum by (outcome) (rate(gitopsreverser_audit_join_skew_seconds_count{arrival="official_first"}[5m]))
+```
+
+`outcome="timed_out"` here equals `rate(audit_shallow_dropped_total[5m])` — two views of the
+same failure.
+
+**What's the margin against `--audit-event-body-ttl` (5m)?** p99 of the proxy's lead time:
+
+```promql
+histogram_quantile(0.99,
+  sum by (le) (rate(gitopsreverser_audit_join_skew_seconds_bucket{arrival="body_first"}[5m])))
+```
+
+Parked bodies expire at `bodyTTL`. If p99 lead time approaches it, bodies are parking far too
+early (or the official stream has stalled) and orphan expiry is imminent.
+
+**Are shallow events being lost?** Non-zero means misconfiguration — no proxy, or an audit
+policy that omits bodies:
+
+```promql
+sum by (gvr, action) (rate(gitopsreverser_audit_shallow_dropped_total[5m]))
+```
+
+**Is the canonical gate causing backpressure?** A shallow official holds the in-pod gate for up
+to `bodyWait`; later officials queue behind it. p95 of that queueing delay:
+
+```promql
+histogram_quantile(0.95,
+  sum by (le) (rate(gitopsreverser_audit_official_gate_wait_seconds_bucket[5m])))
+```
+
+Sub-millisecond is normal. Sustained values near `bodyWait` mean officials are serializing
+behind shallow events — consider whether the audit policy should be supplying bodies directly.
+
+**Is a webhook retry storm happening?** Duplicate drops should be rare:
+
+```promql
+sum by (reason) (rate(gitopsreverser_audit_join_duplicate_dropped_total[5m]))
+```
+
+### Suggested alerts
+
+| Condition | Meaning |
+| --- | --- |
+| `rate(audit_shallow_dropped_total[10m]) > 0` | Bodies are being lost — install the proxy or fix the audit policy. |
+| `histogram_quantile(0.95, ...skew_seconds_bucket{arrival="official_first"}...) > 0.4` (with `bodyWait=500ms`) | Grace period about to be exhausted; raise `--audit-event-body-wait`. |
+| `rate(audit_join_body_late_total[15m]) > 0` sustained | Additional bodies arriving after the decision — proxy slower than `bodyTTL`. |
+| `rate(audit_join_duplicate_dropped_total[5m])` spike | Likely webhook retry storm. |
+
+---
+
+## Git write pipeline
+
+Metrics for the path from matched event to pushed commit. Background:
+[architecture.md → Git Operations](architecture.md#git-operations).
+
+| Metric | Type | Notes |
+| --- | --- | --- |
+| `git_operations_total` | counter | Git operations attempted. |
+| `commits_total` | counter | Commit batches pushed. |
+| `commit_bytes_total` | counter | Approximate bytes written across commits. |
+| `objects_scanned_total` | counter | Objects seen by list/informer paths. |
+| `objects_written_total` | counter | Objects that resulted in a file write. |
+| `files_deleted_total` | counter | Files removed during orphan cleanup. |
+| `rebase_retries_total` | counter | Non-fast-forward push retries (conflict → fetch + replay). |
+| `ownership_conflicts_total` | counter | Marker/lease ownership conflicts. |
+| `lease_acquire_failures_total` | counter | Failures to acquire/renew a lease. |
+| `marker_conflicts_total` | counter | Repository marker conflicts. |
+| `watch_duplicates_skipped_total` | counter | Watch events skipped by content-hash dedup. |
+| `git_push_duration_seconds` | histogram | End-to-end push latency. |
+| `git_commit_queue_size` | gauge | Pending commits queued. |
+| `repo_branch_active_workers` | gauge | Active `BranchWorker` goroutines. |
+| `repo_branch_queue_depth` | gauge | Per-`(provider,branch)` pending-event depth. |
+
+**Push latency p95:**
+
+```promql
+histogram_quantile(0.95, sum by (le) (rate(gitopsreverser_git_push_duration_seconds_bucket[5m])))
+```
+
+**Conflict rate** — how often pushes hit a diverged remote and replayed:
+
+```promql
+rate(gitopsreverser_rebase_retries_total[5m]) / rate(gitopsreverser_commits_total[5m])
+```
+
+A steadily rising ratio means remotes are being written by something other than this operator,
+or multiple branches are contending.
+
+**Is a branch worker backing up?** A persistently rising gauge indicates a stalled remote:
+
+```promql
+gitopsreverser_repo_branch_queue_depth
+```
+
+---
+
+## Secret encryption
+
+Background: [architecture.md → Encryption](architecture.md#encryption). Secrets are never
+committed in plaintext; these metrics confirm the encryption path is healthy.
+
+| Metric | Type | Notes |
+| --- | --- | --- |
+| `secret_encryption_attempts_total` | counter | Total encryption attempts. |
+| `secret_encryption_success_total` | counter | Successful encryptions. |
+| `secret_encryption_failures_total` | counter | Failed encryptions (the write is rejected). |
+| `secret_encryption_cache_hits_total` | counter | Reused already-encrypted content. |
+| `secret_encryption_marker_skips_total` | counter | Marker-based skips reusing cached content. |
+
+**Encryption failure rate** — should be zero; non-zero means Secret writes are being rejected:
+
+```promql
+rate(gitopsreverser_secret_encryption_failures_total[5m])
+```
+
+**Cache effectiveness:**
+
+```promql
+rate(gitopsreverser_secret_encryption_cache_hits_total[5m])
+/
+rate(gitopsreverser_secret_encryption_attempts_total[5m])
+```
+
+---
+
+## Adding a new metric to this document
+
+When you add a metric, add a row here too. The bar: a reader who has never seen the metric
+should learn (1) what it measures, (2) at least one query that answers a real operator
+question, and (3) what a bad value looks like. A metric without an interpretation is noise.

--- a/internal/controller/clusterwatchrule_controller.go
+++ b/internal/controller/clusterwatchrule_controller.go
@@ -29,7 +29,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	ctrlreconcile "sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	configbutleraiv1alpha1 "github.com/ConfigButler/gitops-reverser/api/v1alpha1"
 	"github.com/ConfigButler/gitops-reverser/internal/rulestore"
@@ -308,6 +310,89 @@ func (r *ClusterWatchRuleReconciler) updateStatusWithRetry(
 func (r *ClusterWatchRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&configbutleraiv1alpha1.ClusterWatchRule{}).
+		Watches(
+			&configbutleraiv1alpha1.GitTarget{},
+			handler.EnqueueRequestsFromMapFunc(r.gitTargetToClusterWatchRules),
+		).
+		Watches(
+			&configbutleraiv1alpha1.GitProvider{},
+			handler.EnqueueRequestsFromMapFunc(r.gitProviderToClusterWatchRules),
+		).
 		Named("clusterwatchrule").
 		Complete(r)
+}
+
+// gitTargetToClusterWatchRules maps a GitTarget event to every ClusterWatchRule
+// whose targetRef matches it. ClusterWatchRule is cluster-scoped, so the lookup
+// is cluster-wide.
+func (r *ClusterWatchRuleReconciler) gitTargetToClusterWatchRules(
+	ctx context.Context,
+	obj client.Object,
+) []ctrlreconcile.Request {
+	var rules configbutleraiv1alpha1.ClusterWatchRuleList
+	if err := r.List(ctx, &rules); err != nil {
+		return nil
+	}
+
+	var requests []ctrlreconcile.Request
+	for i := range rules.Items {
+		rule := &rules.Items[i]
+		if rule.Spec.TargetRef.Name != obj.GetName() {
+			continue
+		}
+		if rule.Spec.TargetRef.Namespace != obj.GetNamespace() {
+			continue
+		}
+		requests = append(requests, ctrlreconcile.Request{
+			NamespacedName: types.NamespacedName{Name: rule.Name},
+		})
+	}
+	return requests
+}
+
+// gitProviderToClusterWatchRules maps a GitProvider event to every
+// ClusterWatchRule whose referenced GitTarget points at this provider. This
+// closes the gap where a freshly-arrived GitProvider needs to nudge rules whose
+// own GitTarget event would otherwise not fire (e.g. the GitTarget already
+// existed but its provider lookup was failing).
+func (r *ClusterWatchRuleReconciler) gitProviderToClusterWatchRules(
+	ctx context.Context,
+	obj client.Object,
+) []ctrlreconcile.Request {
+	var targets configbutleraiv1alpha1.GitTargetList
+	if err := r.List(ctx, &targets, client.InNamespace(obj.GetNamespace())); err != nil {
+		return nil
+	}
+
+	matchingTargets := make(map[types.NamespacedName]struct{})
+	for i := range targets.Items {
+		t := &targets.Items[i]
+		if t.Spec.ProviderRef.Name == obj.GetName() {
+			matchingTargets[types.NamespacedName{Name: t.Name, Namespace: t.Namespace}] = struct{}{}
+		}
+	}
+	if len(matchingTargets) == 0 {
+		return nil
+	}
+
+	var rules configbutleraiv1alpha1.ClusterWatchRuleList
+	if err := r.List(ctx, &rules); err != nil {
+		return nil
+	}
+
+	var requests []ctrlreconcile.Request
+	for i := range rules.Items {
+		rule := &rules.Items[i]
+		key := types.NamespacedName{
+			Name:      rule.Spec.TargetRef.Name,
+			Namespace: rule.Spec.TargetRef.Namespace,
+		}
+		if _, ok := matchingTargets[key]; !ok {
+			continue
+		}
+		requests = append(requests, ctrlreconcile.Request{
+			NamespacedName: types.NamespacedName{Name: rule.Name},
+		})
+	}
+	return requests
 }

--- a/internal/controller/clusterwatchrule_controller.go
+++ b/internal/controller/clusterwatchrule_controller.go
@@ -28,9 +28,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	ctrlreconcile "sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	configbutleraiv1alpha1 "github.com/ConfigButler/gitops-reverser/api/v1alpha1"
@@ -310,13 +312,20 @@ func (r *ClusterWatchRuleReconciler) updateStatusWithRetry(
 func (r *ClusterWatchRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&configbutleraiv1alpha1.ClusterWatchRule{}).
+		// GenerationChangedPredicate keeps these watches reacting to a freshly
+		// applied or spec-changed dependency while ignoring the status-only
+		// updates the controllers write themselves — without it every GitTarget
+		// or GitProvider heartbeat would re-list and re-enqueue all
+		// ClusterWatchRules.
 		Watches(
 			&configbutleraiv1alpha1.GitTarget{},
 			handler.EnqueueRequestsFromMapFunc(r.gitTargetToClusterWatchRules),
+			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
 		).
 		Watches(
 			&configbutleraiv1alpha1.GitProvider{},
 			handler.EnqueueRequestsFromMapFunc(r.gitProviderToClusterWatchRules),
+			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
 		).
 		Named("clusterwatchrule").
 		Complete(r)
@@ -331,6 +340,7 @@ func (r *ClusterWatchRuleReconciler) gitTargetToClusterWatchRules(
 ) []ctrlreconcile.Request {
 	var rules configbutleraiv1alpha1.ClusterWatchRuleList
 	if err := r.List(ctx, &rules); err != nil {
+		logDependencyListError(ctx, err, "ClusterWatchRules", obj)
 		return nil
 	}
 
@@ -361,6 +371,7 @@ func (r *ClusterWatchRuleReconciler) gitProviderToClusterWatchRules(
 ) []ctrlreconcile.Request {
 	var targets configbutleraiv1alpha1.GitTargetList
 	if err := r.List(ctx, &targets, client.InNamespace(obj.GetNamespace())); err != nil {
+		logDependencyListError(ctx, err, "GitTargets", obj)
 		return nil
 	}
 
@@ -377,6 +388,7 @@ func (r *ClusterWatchRuleReconciler) gitProviderToClusterWatchRules(
 
 	var rules configbutleraiv1alpha1.ClusterWatchRuleList
 	if err := r.List(ctx, &rules); err != nil {
+		logDependencyListError(ctx, err, "ClusterWatchRules", obj)
 		return nil
 	}
 

--- a/internal/controller/dependency_watches.go
+++ b/internal/controller/dependency_watches.go
@@ -1,0 +1,37 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright 2025 ConfigButler
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// logDependencyListError records a List failure from inside a cross-kind watch
+// map function. Those map functions intentionally degrade to "enqueue nothing"
+// on error — the affected resources still recover on their periodic requeue —
+// so without this log the failure would be entirely invisible.
+func logDependencyListError(ctx context.Context, err error, listKind string, trigger client.Object) {
+	logf.FromContext(ctx).Error(err,
+		"dependency watch: failed to list "+listKind+" for a dependency event; "+
+			"affected resources will recover on the periodic requeue",
+		"trigger", client.ObjectKeyFromObject(trigger))
+}

--- a/internal/controller/dependency_watches_test.go
+++ b/internal/controller/dependency_watches_test.go
@@ -1,0 +1,335 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright 2025 ConfigButler
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	ctrlreconcile "sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	configbutleraiv1alpha1 "github.com/ConfigButler/gitops-reverser/api/v1alpha1"
+)
+
+// newDependencyWatchesTestClient builds a fake client preloaded with the given
+// objects, used by every test in this file. The runtime scheme registers both
+// core types and the ConfigButler v1alpha1 API.
+func newDependencyWatchesTestClient(t *testing.T, objects ...ctrlclient.Object) ctrlclient.Client {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	require.NoError(t, configbutleraiv1alpha1.AddToScheme(scheme))
+
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		Build()
+}
+
+// requestsToKeys flattens a slice of reconcile.Request into a sorted slice of
+// "namespace/name" strings, so test assertions are order-independent. Returns
+// nil when there are no requests so callers can compare against a nil slice.
+func requestsToKeys(requests []ctrlreconcile.Request) []string {
+	if len(requests) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(requests))
+	for _, r := range requests {
+		keys = append(keys, r.NamespacedName.String())
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func gitProvider(name, namespace string) *configbutleraiv1alpha1.GitProvider {
+	return &configbutleraiv1alpha1.GitProvider{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+	}
+}
+
+func gitTarget(name, namespace, providerName string) *configbutleraiv1alpha1.GitTarget {
+	return &configbutleraiv1alpha1.GitTarget{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: configbutleraiv1alpha1.GitTargetSpec{
+			ProviderRef: configbutleraiv1alpha1.GitProviderReference{Name: providerName},
+			Branch:      "main",
+		},
+	}
+}
+
+func watchRule(name, namespace, targetName string) *configbutleraiv1alpha1.WatchRule {
+	return &configbutleraiv1alpha1.WatchRule{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: configbutleraiv1alpha1.WatchRuleSpec{
+			TargetRef: configbutleraiv1alpha1.LocalTargetReference{Name: targetName},
+		},
+	}
+}
+
+func clusterWatchRule(name, targetName, targetNamespace string) *configbutleraiv1alpha1.ClusterWatchRule {
+	return &configbutleraiv1alpha1.ClusterWatchRule{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: configbutleraiv1alpha1.ClusterWatchRuleSpec{
+			TargetRef: configbutleraiv1alpha1.NamespacedTargetReference{
+				Name:      targetName,
+				Namespace: targetNamespace,
+			},
+		},
+	}
+}
+
+// TestGitProviderToGitTargets verifies that a GitProvider event enqueues only
+// the GitTargets in its namespace that reference it.
+func TestGitProviderToGitTargets(t *testing.T) {
+	tests := []struct {
+		name     string
+		objects  []ctrlclient.Object
+		provider ctrlclient.Object
+		want     []string
+	}{
+		{
+			name: "two matching targets in same namespace",
+			objects: []ctrlclient.Object{
+				gitTarget("t1", "ns-a", "provider-a"),
+				gitTarget("t2", "ns-a", "provider-a"),
+				gitTarget("other-provider", "ns-a", "provider-b"),
+			},
+			provider: gitProvider("provider-a", "ns-a"),
+			want:     []string{"ns-a/t1", "ns-a/t2"},
+		},
+		{
+			name: "ignores targets in other namespaces",
+			objects: []ctrlclient.Object{
+				gitTarget("t1", "ns-a", "provider-a"),
+				gitTarget("t2", "ns-b", "provider-a"),
+			},
+			provider: gitProvider("provider-a", "ns-a"),
+			want:     []string{"ns-a/t1"},
+		},
+		{
+			name: "namespace-scoped: same name in different namespace ignored",
+			objects: []ctrlclient.Object{
+				gitTarget("t1", "ns-a", "provider-a"),
+				gitTarget("t2", "ns-b", "provider-a"),
+			},
+			provider: gitProvider("provider-a", "ns-b"),
+			want:     []string{"ns-b/t2"},
+		},
+		{
+			name:     "no targets returns empty",
+			objects:  nil,
+			provider: gitProvider("provider-a", "ns-a"),
+			want:     nil,
+		},
+		{
+			name: "provider name mismatch returns empty",
+			objects: []ctrlclient.Object{
+				gitTarget("t1", "ns-a", "provider-a"),
+			},
+			provider: gitProvider("provider-z", "ns-a"),
+			want:     nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := newDependencyWatchesTestClient(t, tc.objects...)
+			r := &GitTargetReconciler{Client: client}
+
+			got := r.gitProviderToGitTargets(context.Background(), tc.provider)
+
+			assert.Equal(t, tc.want, requestsToKeys(got))
+		})
+	}
+}
+
+// TestGitTargetToClusterWatchRules verifies that a GitTarget event enqueues
+// every ClusterWatchRule whose targetRef matches both name and namespace.
+func TestGitTargetToClusterWatchRules(t *testing.T) {
+	tests := []struct {
+		name    string
+		objects []ctrlclient.Object
+		target  ctrlclient.Object
+		want    []string
+	}{
+		{
+			name: "matches rules by name and namespace",
+			objects: []ctrlclient.Object{
+				clusterWatchRule("rule-1", "target-a", "ns-a"),
+				clusterWatchRule("rule-2", "target-a", "ns-a"),
+				clusterWatchRule("wrong-ns", "target-a", "ns-b"),
+				clusterWatchRule("wrong-name", "target-b", "ns-a"),
+			},
+			target: gitTarget("target-a", "ns-a", "provider-a"),
+			want:   []string{"/rule-1", "/rule-2"},
+		},
+		{
+			name:    "no rules returns empty",
+			objects: nil,
+			target:  gitTarget("target-a", "ns-a", "provider-a"),
+			want:    nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := newDependencyWatchesTestClient(t, tc.objects...)
+			r := &ClusterWatchRuleReconciler{Client: client}
+
+			got := r.gitTargetToClusterWatchRules(context.Background(), tc.target)
+
+			assert.Equal(t, tc.want, requestsToKeys(got))
+		})
+	}
+}
+
+// TestGitProviderToClusterWatchRules verifies that a GitProvider event
+// transitively enqueues ClusterWatchRules via their GitTarget.
+func TestGitProviderToClusterWatchRules(t *testing.T) {
+	tests := []struct {
+		name     string
+		objects  []ctrlclient.Object
+		provider ctrlclient.Object
+		want     []string
+	}{
+		{
+			name: "enqueues rules whose target points at the provider",
+			objects: []ctrlclient.Object{
+				gitTarget("target-a", "ns-a", "provider-a"),
+				gitTarget("target-other", "ns-a", "provider-b"),
+				clusterWatchRule("rule-matched", "target-a", "ns-a"),
+				clusterWatchRule("rule-unrelated", "target-other", "ns-a"),
+			},
+			provider: gitProvider("provider-a", "ns-a"),
+			want:     []string{"/rule-matched"},
+		},
+		{
+			name: "no matching targets returns empty",
+			objects: []ctrlclient.Object{
+				gitTarget("target-a", "ns-a", "provider-b"),
+				clusterWatchRule("rule-matched", "target-a", "ns-a"),
+			},
+			provider: gitProvider("provider-a", "ns-a"),
+			want:     nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := newDependencyWatchesTestClient(t, tc.objects...)
+			r := &ClusterWatchRuleReconciler{Client: client}
+
+			got := r.gitProviderToClusterWatchRules(context.Background(), tc.provider)
+
+			assert.Equal(t, tc.want, requestsToKeys(got))
+		})
+	}
+}
+
+// TestGitTargetToWatchRules verifies that a GitTarget event enqueues every
+// WatchRule in the same namespace that names it.
+func TestGitTargetToWatchRules(t *testing.T) {
+	tests := []struct {
+		name    string
+		objects []ctrlclient.Object
+		target  ctrlclient.Object
+		want    []string
+	}{
+		{
+			name: "matches rules by namespace and target name",
+			objects: []ctrlclient.Object{
+				watchRule("rule-1", "ns-a", "target-a"),
+				watchRule("rule-2", "ns-a", "target-a"),
+				watchRule("wrong-name", "ns-a", "target-b"),
+				watchRule("wrong-ns", "ns-b", "target-a"),
+			},
+			target: gitTarget("target-a", "ns-a", "provider-a"),
+			want:   []string{"ns-a/rule-1", "ns-a/rule-2"},
+		},
+		{
+			name:    "no rules returns empty",
+			objects: nil,
+			target:  gitTarget("target-a", "ns-a", "provider-a"),
+			want:    nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := newDependencyWatchesTestClient(t, tc.objects...)
+			r := &WatchRuleReconciler{Client: client}
+
+			got := r.gitTargetToWatchRules(context.Background(), tc.target)
+
+			assert.Equal(t, tc.want, requestsToKeys(got))
+		})
+	}
+}
+
+// TestGitProviderToWatchRules verifies that a GitProvider event transitively
+// enqueues WatchRules in the provider's namespace via their GitTarget.
+func TestGitProviderToWatchRules(t *testing.T) {
+	tests := []struct {
+		name     string
+		objects  []ctrlclient.Object
+		provider ctrlclient.Object
+		want     []string
+	}{
+		{
+			name: "enqueues rules whose target points at the provider",
+			objects: []ctrlclient.Object{
+				gitTarget("target-a", "ns-a", "provider-a"),
+				gitTarget("target-other", "ns-a", "provider-b"),
+				watchRule("rule-matched", "ns-a", "target-a"),
+				watchRule("rule-unrelated", "ns-a", "target-other"),
+			},
+			provider: gitProvider("provider-a", "ns-a"),
+			want:     []string{"ns-a/rule-matched"},
+		},
+		{
+			name: "no matching targets returns empty",
+			objects: []ctrlclient.Object{
+				gitTarget("target-a", "ns-a", "provider-b"),
+				watchRule("rule-matched", "ns-a", "target-a"),
+			},
+			provider: gitProvider("provider-a", "ns-a"),
+			want:     nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := newDependencyWatchesTestClient(t, tc.objects...)
+			r := &WatchRuleReconciler{Client: client}
+
+			got := r.gitProviderToWatchRules(context.Background(), tc.provider)
+
+			assert.Equal(t, tc.want, requestsToKeys(got))
+		})
+	}
+}

--- a/internal/controller/dependency_watches_test.go
+++ b/internal/controller/dependency_watches_test.go
@@ -20,6 +20,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"sort"
 	"testing"
 
@@ -30,6 +31,9 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	ctrlreconcile "sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	configbutleraiv1alpha1 "github.com/ConfigButler/gitops-reverser/api/v1alpha1"
@@ -332,4 +336,68 @@ func TestGitProviderToWatchRules(t *testing.T) {
 			assert.Equal(t, tc.want, requestsToKeys(got))
 		})
 	}
+}
+
+// TestGenerationChangedPredicateFiltersStatusUpdates verifies PR #149 review
+// issue 2: the cross-kind watches use GenerationChangedPredicate, so they react
+// to a freshly applied or spec-changed dependency but ignore the status-only
+// updates the controllers write themselves.
+func TestGenerationChangedPredicateFiltersStatusUpdates(t *testing.T) {
+	p := predicate.GenerationChangedPredicate{}
+
+	assert.True(t, p.Create(event.CreateEvent{Object: gitProvider("provider-a", "ns-a")}),
+		"a freshly applied dependency must enqueue dependents")
+
+	assert.False(t, p.Update(event.UpdateEvent{
+		ObjectOld: &configbutleraiv1alpha1.GitProvider{ObjectMeta: metav1.ObjectMeta{Generation: 7}},
+		ObjectNew: &configbutleraiv1alpha1.GitProvider{ObjectMeta: metav1.ObjectMeta{Generation: 7}},
+	}), "a status-only update keeps the same generation and must be filtered out")
+
+	assert.True(t, p.Update(event.UpdateEvent{
+		ObjectOld: &configbutleraiv1alpha1.GitProvider{ObjectMeta: metav1.ObjectMeta{Generation: 7}},
+		ObjectNew: &configbutleraiv1alpha1.GitProvider{ObjectMeta: metav1.ObjectMeta{Generation: 8}},
+	}), "a spec change bumps generation and must enqueue dependents")
+}
+
+// newDependencyWatchesListErrorClient builds a fake client whose every List
+// call fails, used to exercise the graceful-degradation path of the cross-kind
+// map functions.
+func newDependencyWatchesListErrorClient(t *testing.T) ctrlclient.Client {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	require.NoError(t, configbutleraiv1alpha1.AddToScheme(scheme))
+
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(
+				context.Context,
+				ctrlclient.WithWatch,
+				ctrlclient.ObjectList,
+				...ctrlclient.ListOption,
+			) error {
+				return errors.New("simulated API server failure")
+			},
+		}).
+		Build()
+}
+
+// TestDependencyMapFunctionsTolerateListErrors verifies PR #149 review issue 5:
+// when the cached List fails, each cross-kind map function degrades gracefully
+// to "enqueue nothing" — affected resources still recover on the periodic
+// requeue — rather than panicking. The accompanying error log is emitted by
+// logDependencyListError.
+func TestDependencyMapFunctionsTolerateListErrors(t *testing.T) {
+	client := newDependencyWatchesListErrorClient(t)
+	ctx := context.Background()
+	provider := gitProvider("provider-a", "ns-a")
+	target := gitTarget("target-a", "ns-a", "provider-a")
+
+	assert.Nil(t, (&GitTargetReconciler{Client: client}).gitProviderToGitTargets(ctx, provider))
+	assert.Nil(t, (&WatchRuleReconciler{Client: client}).gitTargetToWatchRules(ctx, target))
+	assert.Nil(t, (&WatchRuleReconciler{Client: client}).gitProviderToWatchRules(ctx, provider))
+	assert.Nil(t, (&ClusterWatchRuleReconciler{Client: client}).gitTargetToClusterWatchRules(ctx, target))
+	assert.Nil(t, (&ClusterWatchRuleReconciler{Client: client}).gitProviderToClusterWatchRules(ctx, provider))
 }

--- a/internal/controller/gittarget_controller.go
+++ b/internal/controller/gittarget_controller.go
@@ -386,6 +386,8 @@ func (r *GitTargetReconciler) evaluateSnapshotGate(
 		if err != nil {
 			return nil, metav1.ConditionFalse, "", 0, err
 		}
+		gitDest := types.NewResourceReference(target.Name, target.Namespace)
+		r.EventRouter.ReconcilerManager.CreateReconciler(gitDest, stream)
 		return stream, metav1.ConditionTrue, MsgSnapshotCompleted, 0, nil
 	}
 

--- a/internal/controller/gittarget_controller.go
+++ b/internal/controller/gittarget_controller.go
@@ -904,6 +904,10 @@ func (r *GitTargetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&configbutleraiv1alpha1.GitTarget{}).
 		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(r.encryptionSecretToGitTargets)).
+		Watches(
+			&configbutleraiv1alpha1.GitProvider{},
+			handler.EnqueueRequestsFromMapFunc(r.gitProviderToGitTargets),
+		).
 		Named("gittarget").
 		Complete(r)
 }
@@ -930,6 +934,32 @@ func (r *GitTargetReconciler) encryptionSecretToGitTargets(
 				NamespacedName: k8stypes.NamespacedName{Name: t.Name, Namespace: t.Namespace},
 			})
 		}
+	}
+	return requests
+}
+
+// gitProviderToGitTargets maps a GitProvider event to every GitTarget in the
+// same namespace that references it, so a freshly-arrived provider re-enqueues
+// any dependents currently stuck on ProviderNotFound instead of waiting for the
+// periodic RequeueShortInterval.
+func (r *GitTargetReconciler) gitProviderToGitTargets(
+	ctx context.Context,
+	obj client.Object,
+) []ctrlreconcile.Request {
+	var targets configbutleraiv1alpha1.GitTargetList
+	if err := r.List(ctx, &targets, client.InNamespace(obj.GetNamespace())); err != nil {
+		return nil
+	}
+
+	var requests []ctrlreconcile.Request
+	for i := range targets.Items {
+		t := &targets.Items[i]
+		if t.Spec.ProviderRef.Name != obj.GetName() {
+			continue
+		}
+		requests = append(requests, ctrlreconcile.Request{
+			NamespacedName: k8stypes.NamespacedName{Name: t.Name, Namespace: t.Namespace},
+		})
 	}
 	return requests
 }

--- a/internal/controller/gittarget_controller.go
+++ b/internal/controller/gittarget_controller.go
@@ -35,9 +35,11 @@ import (
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	ctrlreconcile "sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	configbutleraiv1alpha1 "github.com/ConfigButler/gitops-reverser/api/v1alpha1"
@@ -387,7 +389,7 @@ func (r *GitTargetReconciler) evaluateSnapshotGate(
 			return nil, metav1.ConditionFalse, "", 0, err
 		}
 		gitDest := types.NewResourceReference(target.Name, target.Namespace)
-		r.EventRouter.ReconcilerManager.CreateReconciler(gitDest, stream)
+		r.EventRouter.ReconcilerManager.CreateReconciler(ctx, gitDest, stream)
 		return stream, metav1.ConditionTrue, MsgSnapshotCompleted, 0, nil
 	}
 
@@ -401,7 +403,7 @@ func (r *GitTargetReconciler) evaluateSnapshotGate(
 	stream.BeginReconciliation()
 
 	gitDest := types.NewResourceReference(target.Name, target.Namespace)
-	reconciler := r.EventRouter.ReconcilerManager.CreateReconciler(gitDest, stream)
+	reconciler := r.EventRouter.ReconcilerManager.CreateReconciler(ctx, gitDest, stream)
 	if err := reconciler.StartReconciliation(ctx); err != nil {
 		return stream, metav1.ConditionFalse, "", 0, fmt.Errorf(
 			"failed to start initial snapshot reconciliation: %w",
@@ -906,9 +908,14 @@ func (r *GitTargetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&configbutleraiv1alpha1.GitTarget{}).
 		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(r.encryptionSecretToGitTargets)).
+		// GenerationChangedPredicate keeps this watch reacting to a freshly
+		// applied or spec-changed GitProvider while ignoring the status-only
+		// updates the controllers write themselves — without it every provider
+		// heartbeat would re-list and re-enqueue all dependent GitTargets.
 		Watches(
 			&configbutleraiv1alpha1.GitProvider{},
 			handler.EnqueueRequestsFromMapFunc(r.gitProviderToGitTargets),
+			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
 		).
 		Named("gittarget").
 		Complete(r)
@@ -950,6 +957,7 @@ func (r *GitTargetReconciler) gitProviderToGitTargets(
 ) []ctrlreconcile.Request {
 	var targets configbutleraiv1alpha1.GitTargetList
 	if err := r.List(ctx, &targets, client.InNamespace(obj.GetNamespace())); err != nil {
+		logDependencyListError(ctx, err, "GitTargets", obj)
 		return nil
 	}
 

--- a/internal/controller/watchrule_controller.go
+++ b/internal/controller/watchrule_controller.go
@@ -30,7 +30,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	ctrlreconcile "sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	configbutleraiv1alpha1 "github.com/ConfigButler/gitops-reverser/api/v1alpha1"
 	"github.com/ConfigButler/gitops-reverser/internal/rulestore"
@@ -328,6 +330,83 @@ func (r *WatchRuleReconciler) updateStatusWithRetry(
 func (r *WatchRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&configbutleraiv1alpha1.WatchRule{}).
+		Watches(
+			&configbutleraiv1alpha1.GitTarget{},
+			handler.EnqueueRequestsFromMapFunc(r.gitTargetToWatchRules),
+		).
+		Watches(
+			&configbutleraiv1alpha1.GitProvider{},
+			handler.EnqueueRequestsFromMapFunc(r.gitProviderToWatchRules),
+		).
 		Named("watchrule").
 		Complete(r)
+}
+
+// gitTargetToWatchRules maps a GitTarget event to every WatchRule in the
+// GitTarget's namespace that references it. WatchRule.spec.targetRef is a
+// LocalTargetReference, so candidates only live in the same namespace as the
+// GitTarget.
+func (r *WatchRuleReconciler) gitTargetToWatchRules(
+	ctx context.Context,
+	obj client.Object,
+) []ctrlreconcile.Request {
+	var rules configbutleraiv1alpha1.WatchRuleList
+	if err := r.List(ctx, &rules, client.InNamespace(obj.GetNamespace())); err != nil {
+		return nil
+	}
+
+	var requests []ctrlreconcile.Request
+	for i := range rules.Items {
+		rule := &rules.Items[i]
+		if rule.Spec.TargetRef.Name != obj.GetName() {
+			continue
+		}
+		requests = append(requests, ctrlreconcile.Request{
+			NamespacedName: types.NamespacedName{Name: rule.Name, Namespace: rule.Namespace},
+		})
+	}
+	return requests
+}
+
+// gitProviderToWatchRules maps a GitProvider event to every WatchRule (in the
+// GitProvider's namespace) whose referenced GitTarget points at this provider.
+// Mirrors the equivalent helper on ClusterWatchRuleReconciler so that an
+// arriving provider doesn't have to wait for a separate GitTarget event to
+// reach the rule.
+func (r *WatchRuleReconciler) gitProviderToWatchRules(
+	ctx context.Context,
+	obj client.Object,
+) []ctrlreconcile.Request {
+	var targets configbutleraiv1alpha1.GitTargetList
+	if err := r.List(ctx, &targets, client.InNamespace(obj.GetNamespace())); err != nil {
+		return nil
+	}
+
+	matchingTargets := make(map[string]struct{})
+	for i := range targets.Items {
+		t := &targets.Items[i]
+		if t.Spec.ProviderRef.Name == obj.GetName() {
+			matchingTargets[t.Name] = struct{}{}
+		}
+	}
+	if len(matchingTargets) == 0 {
+		return nil
+	}
+
+	var rules configbutleraiv1alpha1.WatchRuleList
+	if err := r.List(ctx, &rules, client.InNamespace(obj.GetNamespace())); err != nil {
+		return nil
+	}
+
+	var requests []ctrlreconcile.Request
+	for i := range rules.Items {
+		rule := &rules.Items[i]
+		if _, ok := matchingTargets[rule.Spec.TargetRef.Name]; !ok {
+			continue
+		}
+		requests = append(requests, ctrlreconcile.Request{
+			NamespacedName: types.NamespacedName{Name: rule.Name, Namespace: rule.Namespace},
+		})
+	}
+	return requests
 }

--- a/internal/controller/watchrule_controller.go
+++ b/internal/controller/watchrule_controller.go
@@ -29,9 +29,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	ctrlreconcile "sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	configbutleraiv1alpha1 "github.com/ConfigButler/gitops-reverser/api/v1alpha1"
@@ -330,13 +332,19 @@ func (r *WatchRuleReconciler) updateStatusWithRetry(
 func (r *WatchRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&configbutleraiv1alpha1.WatchRule{}).
+		// GenerationChangedPredicate keeps these watches reacting to a freshly
+		// applied or spec-changed dependency while ignoring the status-only
+		// updates the controllers write themselves — without it every GitTarget
+		// or GitProvider heartbeat would re-list and re-enqueue all WatchRules.
 		Watches(
 			&configbutleraiv1alpha1.GitTarget{},
 			handler.EnqueueRequestsFromMapFunc(r.gitTargetToWatchRules),
+			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
 		).
 		Watches(
 			&configbutleraiv1alpha1.GitProvider{},
 			handler.EnqueueRequestsFromMapFunc(r.gitProviderToWatchRules),
+			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
 		).
 		Named("watchrule").
 		Complete(r)
@@ -352,6 +360,7 @@ func (r *WatchRuleReconciler) gitTargetToWatchRules(
 ) []ctrlreconcile.Request {
 	var rules configbutleraiv1alpha1.WatchRuleList
 	if err := r.List(ctx, &rules, client.InNamespace(obj.GetNamespace())); err != nil {
+		logDependencyListError(ctx, err, "WatchRules", obj)
 		return nil
 	}
 
@@ -379,6 +388,7 @@ func (r *WatchRuleReconciler) gitProviderToWatchRules(
 ) []ctrlreconcile.Request {
 	var targets configbutleraiv1alpha1.GitTargetList
 	if err := r.List(ctx, &targets, client.InNamespace(obj.GetNamespace())); err != nil {
+		logDependencyListError(ctx, err, "GitTargets", obj)
 		return nil
 	}
 
@@ -395,6 +405,7 @@ func (r *WatchRuleReconciler) gitProviderToWatchRules(
 
 	var rules configbutleraiv1alpha1.WatchRuleList
 	if err := r.List(ctx, &rules, client.InNamespace(obj.GetNamespace())); err != nil {
+		logDependencyListError(ctx, err, "WatchRules", obj)
 		return nil
 	}
 

--- a/internal/git/commit.go
+++ b/internal/git/commit.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"text/template"
 	"time"
+	"unicode"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing/object"
@@ -153,8 +154,8 @@ func commitOptionsFor(
 	when time.Time,
 ) *git.CommitOptions {
 	committer := operatorSignature(config, when)
-	author := pendingWrite.Author()
-	if author == "" {
+	author := pendingWrite.AuthorUserInfo()
+	if author.Username == "" {
 		return &git.CommitOptions{
 			Author:    committer,
 			Committer: committer,
@@ -164,8 +165,8 @@ func commitOptionsFor(
 
 	return &git.CommitOptions{
 		Author: &object.Signature{
-			Name:  author,
-			Email: ConstructSafeEmail(author, "cluster.local"),
+			Name:  authorName(author),
+			Email: authorEmail(author),
 			When:  when,
 		},
 		Committer: committer,
@@ -173,12 +174,48 @@ func commitOptionsFor(
 	}
 }
 
+// validEmailRegex matches a syntactically valid email address. It recognises a
+// username that is already an email and validates an OIDC-supplied email claim
+// before trusting it in a signature header.
+var validEmailRegex = regexp.MustCompile(`^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`)
+
+// authorName returns the git author Name for a user: the OIDC display name
+// when present and safe to place in a signature header, otherwise the
+// Kubernetes username.
+func authorName(user UserInfo) string {
+	if name := strings.TrimSpace(user.DisplayName); name != "" && isSafeSignatureField(name) {
+		return name
+	}
+	return user.Username
+}
+
+// authorEmail returns the git author Email for a user: the OIDC email claim
+// when present and a valid address, otherwise a safe address constructed from
+// the username.
+func authorEmail(user UserInfo) string {
+	if email := strings.TrimSpace(user.Email); validEmailRegex.MatchString(email) {
+		return email
+	}
+	return ConstructSafeEmail(user.Username, "cluster.local")
+}
+
+// isSafeSignatureField reports whether s can be placed verbatim into a git
+// signature header field. Control characters (notably newlines) and the angle
+// brackets that delimit the email would corrupt the commit object.
+func isSafeSignatureField(s string) bool {
+	for _, r := range s {
+		if r == '<' || r == '>' || unicode.IsControl(r) {
+			return false
+		}
+	}
+	return true
+}
+
 // ConstructSafeEmail takes a raw username and a domain and creates a valid
 // git-compliant email address.
 func ConstructSafeEmail(username string, domain string) string {
 	// Check if username is already a valid email address.
-	emailRegex := regexp.MustCompile(`^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`)
-	if emailRegex.MatchString(username) {
+	if validEmailRegex.MatchString(username) {
 		return username
 	}
 

--- a/internal/git/commit_test.go
+++ b/internal/git/commit_test.go
@@ -191,6 +191,65 @@ func TestCommitOptionsFor_NonEmptyAuthorIsHonored(t *testing.T) {
 	assert.Equal(t, when, options.Author.When)
 }
 
+func TestCommitOptionsFor_OIDCDisplayNameAndEmailAreHonored(t *testing.T) {
+	config := ResolveCommitConfig(nil)
+	pendingWrite := PendingWrite{
+		Kind: PendingWriteCommit,
+		Events: []Event{{
+			UserInfo: UserInfo{
+				Username:    "https://keycloak/realms/cozy#simon",
+				DisplayName: "Simon Koudijs",
+				Email:       "simon@koudijs.dev",
+			},
+		}},
+	}
+
+	options := commitOptionsFor(pendingWrite, config, nil, time.Now())
+
+	require.NotNil(t, options.Author)
+	assert.Equal(t, "Simon Koudijs", options.Author.Name)
+	assert.Equal(t, "simon@koudijs.dev", options.Author.Email)
+}
+
+func TestCommitOptionsFor_UnusableOIDCFieldsFallBackToUsername(t *testing.T) {
+	config := ResolveCommitConfig(nil)
+	when := time.Now()
+
+	tests := []struct {
+		name        string
+		displayName string
+		email       string
+	}{
+		{"newline in display name", "Simon\nKoudijs", "simon@koudijs.dev"},
+		{"angle brackets in display name", "Simon <root>", "simon@koudijs.dev"},
+		{"whitespace-only display name", "   ", "simon@koudijs.dev"},
+		{"non-email in email claim", "Simon Koudijs", "not-an-email"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pendingWrite := PendingWrite{
+				Kind: PendingWriteCommit,
+				Events: []Event{{
+					UserInfo: UserInfo{
+						Username:    "alice",
+						DisplayName: tc.displayName,
+						Email:       tc.email,
+					},
+				}},
+			}
+
+			options := commitOptionsFor(pendingWrite, config, nil, when)
+
+			require.NotNil(t, options.Author)
+			assert.NotContains(t, options.Author.Name, "\n")
+			assert.NotContains(t, options.Author.Name, "<")
+			require.True(t, validEmailRegex.MatchString(options.Author.Email),
+				"author email %q must be a valid address", options.Author.Email)
+		})
+	}
+}
+
 func TestRenderEventCommitMessage_CreateOperation(t *testing.T) {
 	event := newCommitTestEvent("pods", "default", "test-pod", "CREATE", "john.doe@example.com")
 

--- a/internal/git/commit_test.go
+++ b/internal/git/commit_test.go
@@ -199,7 +199,7 @@ func TestCommitOptionsFor_OIDCDisplayNameAndEmailAreHonored(t *testing.T) {
 			UserInfo: UserInfo{
 				Username:    "https://keycloak/realms/cozy#simon",
 				DisplayName: "Simon Koudijs",
-				Email:       "simon@koudijs.dev",
+				Email:       "something@configbutler.ai",
 			},
 		}},
 	}
@@ -208,7 +208,7 @@ func TestCommitOptionsFor_OIDCDisplayNameAndEmailAreHonored(t *testing.T) {
 
 	require.NotNil(t, options.Author)
 	assert.Equal(t, "Simon Koudijs", options.Author.Name)
-	assert.Equal(t, "simon@koudijs.dev", options.Author.Email)
+	assert.Equal(t, "something@configbutler.ai", options.Author.Email)
 }
 
 func TestCommitOptionsFor_UnusableOIDCFieldsFallBackToUsername(t *testing.T) {
@@ -220,9 +220,9 @@ func TestCommitOptionsFor_UnusableOIDCFieldsFallBackToUsername(t *testing.T) {
 		displayName string
 		email       string
 	}{
-		{"newline in display name", "Simon\nKoudijs", "simon@koudijs.dev"},
-		{"angle brackets in display name", "Simon <root>", "simon@koudijs.dev"},
-		{"whitespace-only display name", "   ", "simon@koudijs.dev"},
+		{"newline in display name", "Simon\nKoudijs", "something@configbutler.ai"},
+		{"angle brackets in display name", "Simon <root>", "something@configbutler.ai"},
+		{"whitespace-only display name", "   ", "something@configbutler.ai"},
 		{"non-email in email claim", "Simon Koudijs", "not-an-email"},
 	}
 

--- a/internal/git/pending_writes.go
+++ b/internal/git/pending_writes.go
@@ -193,12 +193,21 @@ func (p PendingWrite) MessageKind() CommitMessageKind {
 	return CommitMessageGrouped
 }
 
-// Author returns the grouped commit author for commit-shaped pending writes.
+// Author returns the grouped commit author username for commit-shaped pending
+// writes. It is the stable identity used for window coalescing and the grouped
+// commit message; see AuthorUserInfo for the full signing identity.
 func (p PendingWrite) Author() string {
+	return p.AuthorUserInfo().Username
+}
+
+// AuthorUserInfo returns the full author identity for commit-shaped pending
+// writes, including any OIDC display name and email. Atomic and empty writes
+// have no per-user author and return the zero value.
+func (p PendingWrite) AuthorUserInfo() UserInfo {
 	if p.Kind == PendingWriteAtomic || len(p.Events) == 0 {
-		return ""
+		return UserInfo{}
 	}
-	return p.Events[0].UserInfo.Username
+	return p.Events[0].UserInfo
 }
 
 // Target returns the single resolved target metadata for this pending write.

--- a/internal/git/types.go
+++ b/internal/git/types.go
@@ -94,6 +94,12 @@ func (k BranchKey) String() string {
 type UserInfo struct {
 	Username string
 	UID      string
+	// DisplayName is the human-readable name from the OIDC "name" claim, when
+	// the audit event carries it. Empty means "fall back to Username".
+	DisplayName string
+	// Email is the address from the OIDC "email" claim, when the audit event
+	// carries it. Empty means "fall back to ConstructSafeEmail(Username)".
+	Email string
 }
 
 // CommitMode defines how a write request should be committed.

--- a/internal/queue/redis_audit_consumer.go
+++ b/internal/queue/redis_audit_consumer.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/redis/go-redis/v9"
+	authnv1 "k8s.io/api/authentication/v1"
 	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -497,14 +498,41 @@ func buildGitEvent(
 	}
 }
 
-// resolveUserInfo extracts the effective username from an audit event, preferring
-// the impersonated user when present.
+const (
+	// displayNameExtraKey is the audit-event user.extra key carrying the OIDC
+	// "name" claim, when the API server is configured to map it.
+	displayNameExtraKey = "configbutler.ai/claims/display-name"
+	// emailExtraKey is the audit-event user.extra key carrying the OIDC
+	// "email" claim, when the API server is configured to map it.
+	emailExtraKey = "configbutler.ai/claims/email"
+)
+
+// resolveUserInfo extracts the effective user identity from an audit event,
+// preferring the impersonated user when present. When the effective user
+// carries the OIDC display-name / email extras, those populate the optional
+// UserInfo fields; absent values are left empty so commit authoring falls back
+// to the username.
 func resolveUserInfo(event auditv1.Event) git.UserInfo {
-	username := event.User.Username
+	user := event.User
 	if event.ImpersonatedUser != nil && event.ImpersonatedUser.Username != "" {
-		username = event.ImpersonatedUser.Username
+		user = *event.ImpersonatedUser
 	}
-	return git.UserInfo{Username: username}
+
+	return git.UserInfo{
+		Username:    user.Username,
+		DisplayName: firstExtraValue(user.Extra, displayNameExtraKey),
+		Email:       firstExtraValue(user.Extra, emailExtraKey),
+	}
+}
+
+// firstExtraValue returns the first value for key in an audit event's
+// user.extra map, or "" when the key is absent or carries no values.
+func firstExtraValue(extra map[string]authnv1.ExtraValue, key string) string {
+	values := extra[key]
+	if len(values) == 0 {
+		return ""
+	}
+	return values[0]
 }
 
 // ackMessage ACKs a single message, logging any error.

--- a/internal/queue/redis_audit_consumer_test.go
+++ b/internal/queue/redis_audit_consumer_test.go
@@ -225,11 +225,11 @@ func TestResolveUserInfo(t *testing.T) {
 		ev.User.Username = "https://idp/realms/cozy#simon"
 		ev.User.Extra = map[string]authv1.ExtraValue{
 			displayNameExtraKey: {"Simon Koudijs"},
-			emailExtraKey:       {"simon@koudijs.dev"},
+			emailExtraKey:       {"something@configbutler.ai"},
 		}
 		ui := resolveUserInfo(ev)
 		assert.Equal(t, "Simon Koudijs", ui.DisplayName)
-		assert.Equal(t, "simon@koudijs.dev", ui.Email)
+		assert.Equal(t, "something@configbutler.ai", ui.Email)
 	})
 
 	t.Run("extras are read from the impersonated user", func(t *testing.T) {

--- a/internal/queue/redis_audit_consumer_test.go
+++ b/internal/queue/redis_audit_consumer_test.go
@@ -211,6 +211,57 @@ func TestResolveUserInfo(t *testing.T) {
 		ui := resolveUserInfo(ev)
 		assert.Equal(t, "alice", ui.Username)
 	})
+
+	t.Run("no extras leaves display name and email empty", func(t *testing.T) {
+		ev := auditv1.Event{}
+		ev.User.Username = "alice"
+		ui := resolveUserInfo(ev)
+		assert.Empty(t, ui.DisplayName)
+		assert.Empty(t, ui.Email)
+	})
+
+	t.Run("OIDC extras populate display name and email", func(t *testing.T) {
+		ev := auditv1.Event{}
+		ev.User.Username = "https://idp/realms/cozy#simon"
+		ev.User.Extra = map[string]authv1.ExtraValue{
+			displayNameExtraKey: {"Simon Koudijs"},
+			emailExtraKey:       {"simon@koudijs.dev"},
+		}
+		ui := resolveUserInfo(ev)
+		assert.Equal(t, "Simon Koudijs", ui.DisplayName)
+		assert.Equal(t, "simon@koudijs.dev", ui.Email)
+	})
+
+	t.Run("extras are read from the impersonated user", func(t *testing.T) {
+		ev := auditv1.Event{
+			ImpersonatedUser: &authv1.UserInfo{
+				Username: "bob",
+				Extra: map[string]authv1.ExtraValue{
+					displayNameExtraKey: {"Bob Builder"},
+					emailExtraKey:       {"bob@example.com"},
+				},
+			},
+		}
+		ev.User.Username = "alice"
+		ev.User.Extra = map[string]authv1.ExtraValue{
+			displayNameExtraKey: {"Alice Authn"},
+			emailExtraKey:       {"alice@example.com"},
+		}
+		ui := resolveUserInfo(ev)
+		assert.Equal(t, "bob", ui.Username)
+		assert.Equal(t, "Bob Builder", ui.DisplayName)
+		assert.Equal(t, "bob@example.com", ui.Email)
+	})
+
+	t.Run("empty extra value slice is treated as absent", func(t *testing.T) {
+		ev := auditv1.Event{}
+		ev.User.Username = "alice"
+		ev.User.Extra = map[string]authv1.ExtraValue{
+			displayNameExtraKey: {},
+		}
+		ui := resolveUserInfo(ev)
+		assert.Empty(t, ui.DisplayName)
+	})
 }
 
 // --- extractObject ---

--- a/internal/reconcile/reconciler_manager.go
+++ b/internal/reconcile/reconciler_manager.go
@@ -37,6 +37,8 @@ type ReconcilerManager struct {
 		ProcessControlEvent(ctx context.Context, event events.ControlEvent) error
 	}
 	logger logr.Logger
+
+	onReconcilerCreated func(types.ResourceReference)
 }
 
 // NewReconcilerManager creates a new ReconcilerManager.
@@ -62,6 +64,13 @@ func (m *ReconcilerManager) SetEventRouter(
 	m.eventRouter = eventRouter
 }
 
+// SetOnReconcilerCreated registers a callback fired after a new FolderReconciler is created.
+func (m *ReconcilerManager) SetOnReconcilerCreated(callback func(types.ResourceReference)) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.onReconcilerCreated = callback
+}
+
 // CreateReconciler creates or retrieves a FolderReconciler for the given GitDestination.
 func (m *ReconcilerManager) CreateReconciler(
 	gitDest types.ResourceReference,
@@ -70,16 +79,21 @@ func (m *ReconcilerManager) CreateReconciler(
 	key := gitDest.Key()
 
 	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	if reconciler, exists := m.reconcilers[key]; exists {
+		m.mu.Unlock()
 		m.logger.V(1).Info("Reconciler already exists", "gitDest", gitDest.String())
 		return reconciler
 	}
 
 	reconciler := NewFolderReconciler(gitDest, requestEmitter, m, m.logger)
 	m.reconcilers[key] = reconciler
+	callback := m.onReconcilerCreated
+	m.mu.Unlock()
+
 	m.logger.Info("Created new FolderReconciler", "gitDest", gitDest.String())
+	if callback != nil {
+		callback(gitDest)
+	}
 	return reconciler
 }
 

--- a/internal/reconcile/reconciler_manager.go
+++ b/internal/reconcile/reconciler_manager.go
@@ -38,7 +38,7 @@ type ReconcilerManager struct {
 	}
 	logger logr.Logger
 
-	onReconcilerCreated func(types.ResourceReference)
+	onReconcilerCreated func(context.Context, types.ResourceReference)
 }
 
 // NewReconcilerManager creates a new ReconcilerManager.
@@ -65,14 +65,18 @@ func (m *ReconcilerManager) SetEventRouter(
 }
 
 // SetOnReconcilerCreated registers a callback fired after a new FolderReconciler is created.
-func (m *ReconcilerManager) SetOnReconcilerCreated(callback func(types.ResourceReference)) {
+func (m *ReconcilerManager) SetOnReconcilerCreated(callback func(context.Context, types.ResourceReference)) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.onReconcilerCreated = callback
 }
 
 // CreateReconciler creates or retrieves a FolderReconciler for the given GitDestination.
+// ctx is the caller's reconcile context; it is forwarded to the
+// onReconcilerCreated callback so downstream work (e.g. snapshot replay) is
+// cancellable rather than running on a detached context.Background().
 func (m *ReconcilerManager) CreateReconciler(
+	ctx context.Context,
 	gitDest types.ResourceReference,
 	requestEmitter WriteRequestEmitter,
 ) *FolderReconciler {
@@ -92,7 +96,7 @@ func (m *ReconcilerManager) CreateReconciler(
 
 	m.logger.Info("Created new FolderReconciler", "gitDest", gitDest.String())
 	if callback != nil {
-		callback(gitDest)
+		callback(ctx, gitDest)
 	}
 	return reconciler
 }

--- a/internal/telemetry/exporter.go
+++ b/internal/telemetry/exporter.go
@@ -81,6 +81,12 @@ var (
 	AuditShallowDroppedTotal metric.Int64Counter
 	// AuditJoinBodyLateTotal counts additional bodies that arrived after a canonical decision.
 	AuditJoinBodyLateTotal metric.Int64Counter
+	// AuditJoinSkewSeconds records the arrival skew between an official audit event and its
+	// matching additional body, labelled by which arrived first and how the join resolved.
+	AuditJoinSkewSeconds metric.Float64Histogram
+	// AuditOfficialGateWaitSeconds records how long an official audit event waited to acquire
+	// the in-pod canonical ordering gate before processing.
+	AuditOfficialGateWaitSeconds metric.Float64Histogram
 	// SecretEncryptionAttemptsTotal counts total Secret encryption attempts.
 	SecretEncryptionAttemptsTotal metric.Int64Counter
 	// SecretEncryptionSuccessTotal counts successful Secret encryptions.
@@ -119,8 +125,9 @@ func InitOTLPExporter(_ context.Context) (func(context.Context) error, error) {
 		dest *metric.Int64Counter
 	}
 	type hSpec struct {
-		name string
-		dest *metric.Float64Histogram
+		name    string
+		dest    *metric.Float64Histogram
+		buckets []float64
 	}
 	type uSpec struct {
 		name string
@@ -162,11 +169,20 @@ func InitOTLPExporter(_ context.Context) (func(context.Context) error, error) {
 		*s.dest = v
 	}
 
+	// auditJoinBuckets span the wait budget (sub-second) and the parked-body TTL margin
+	// (seconds to minutes) so one set of boundaries fits both skew and gate-wait timings.
+	auditJoinBuckets := []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 5, 30, 300}
 	hists := []hSpec{
-		{"gitopsreverser_git_push_duration_seconds", &GitPushDurationSeconds},
+		{"gitopsreverser_git_push_duration_seconds", &GitPushDurationSeconds, nil},
+		{"gitopsreverser_audit_join_skew_seconds", &AuditJoinSkewSeconds, auditJoinBuckets},
+		{"gitopsreverser_audit_official_gate_wait_seconds", &AuditOfficialGateWaitSeconds, auditJoinBuckets},
 	}
 	for _, s := range hists {
-		v, err := otelMeter.Float64Histogram(s.name)
+		opts := []metric.Float64HistogramOption{}
+		if len(s.buckets) > 0 {
+			opts = append(opts, metric.WithExplicitBucketBoundaries(s.buckets...))
+		}
+		v, err := otelMeter.Float64Histogram(s.name, opts...)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/watch/event_router.go
+++ b/internal/watch/event_router.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -52,6 +53,14 @@ type EventRouter struct {
 	// Registry of GitTargetEventStreams by gitDest key
 	gitTargetStreams map[string]*reconcile.GitTargetEventStream
 	streamsMu        sync.RWMutex
+
+	// snapshotDeliveryDrops counts how many cluster/repo state events were
+	// produced but had no registered FolderReconciler to receive them. This
+	// happens, for example, when WatchManager.ReconcileForRuleChange fires its
+	// snapshot before the GitTargetReconciler has had a chance to create a
+	// FolderReconciler. Each drop is a silently-missed backfill. Exposed for
+	// tests and will be wired to a Prometheus gauge later.
+	snapshotDeliveryDrops atomic.Int64
 }
 
 // NewEventRouter creates a new event router.
@@ -70,6 +79,13 @@ func NewEventRouter(
 		Log:               log,
 		gitTargetStreams:  make(map[string]*reconcile.GitTargetEventStream),
 	}
+}
+
+// SnapshotDeliveryDrops returns the number of state events that were emitted
+// for a GitDest that had no registered FolderReconciler at the time. A
+// non-zero value indicates a missed snapshot delivery.
+func (r *EventRouter) SnapshotDeliveryDrops() int64 {
+	return r.snapshotDeliveryDrops.Load()
 }
 
 // RouteEvent sends an event to the worker for (provider, branch).
@@ -244,6 +260,7 @@ func (r *EventRouter) handleReconcileResource(_ context.Context, event events.Co
 func (r *EventRouter) RouteRepoStateEvent(event events.RepoStateEvent) error {
 	reconciler, exists := r.ReconcilerManager.GetReconciler(event.GitDest)
 	if !exists {
+		r.snapshotDeliveryDrops.Add(1)
 		r.Log.V(1).Info("No reconciler found", "gitDest", event.GitDest.String())
 		return nil
 	}
@@ -255,6 +272,7 @@ func (r *EventRouter) RouteRepoStateEvent(event events.RepoStateEvent) error {
 func (r *EventRouter) RouteClusterStateEvent(event events.ClusterStateEvent) error {
 	reconciler, exists := r.ReconcilerManager.GetReconciler(event.GitDest)
 	if !exists {
+		r.snapshotDeliveryDrops.Add(1)
 		r.Log.V(1).Info("No reconciler found", "gitDest", event.GitDest.String())
 		return nil
 	}

--- a/internal/watch/manager.go
+++ b/internal/watch/manager.go
@@ -1366,8 +1366,9 @@ func (m *Manager) markRuleSetSnapshotDelivered(target ruleSetSnapshotTarget) {
 }
 
 // MaybeReplaySnapshot emits a pending rule-change snapshot once a FolderReconciler
-// exists for gitDest. It is called by ReconcilerManager when a reconciler is created.
-func (m *Manager) MaybeReplaySnapshot(gitDest types.ResourceReference) {
+// exists for gitDest. It is called by ReconcilerManager when a reconciler is
+// created; ctx is the originating reconcile context so the replay is cancellable.
+func (m *Manager) MaybeReplaySnapshot(ctx context.Context, gitDest types.ResourceReference) {
 	if m == nil {
 		return
 	}
@@ -1386,7 +1387,7 @@ func (m *Manager) MaybeReplaySnapshot(gitDest types.ResourceReference) {
 	target := ruleSetSnapshotTarget{gitDest: gitDest, hash: hash}
 	log := m.Log.WithName("reconcile")
 	m.EventRouter.BeginReconciliationForStream(gitDest)
-	m.emitSnapshotForRuleChange(context.Background(), log, []ruleSetSnapshotTarget{target})
+	m.emitSnapshotForRuleChange(ctx, log, []ruleSetSnapshotTarget{target})
 	m.EventRouter.CompleteReconciliationForStream(gitDest)
 }
 

--- a/internal/watch/manager.go
+++ b/internal/watch/manager.go
@@ -23,7 +23,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
+	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -82,6 +85,34 @@ type Manager struct {
 	// dynamicClient overrides the config-built dynamic client when non-nil.
 	// Used in tests to inject a fake client without a real REST config.
 	dynamicClient dynamic.Interface
+
+	// discoveryFilter, when non-nil, replaces FilterDiscoverableGVRs in
+	// ReconcileForRuleChange. Used in tests to bypass the real discovery client
+	// (which is unavailable without a real REST config). Production code leaves
+	// it nil and uses the default discovery-backed implementation.
+	discoveryFilter func(context.Context, []GVR) []GVR
+
+	// snapshotEmitCount tracks how many times emitSnapshotForRuleChange has
+	// actually emitted snapshots for at least one affected GitTarget. Useful for
+	// tests to observe the snapshot-trigger contract and will be exposed as a
+	// Prometheus metric later.
+	snapshotEmitCount atomic.Int64
+
+	// ruleSetSnapshotMu protects per-GitTarget snapshot delivery state.
+	ruleSetSnapshotMu        sync.Mutex
+	lastDeliveredRuleSetHash map[string]uint64
+	pendingRuleSetHash       map[string]uint64
+}
+
+// SnapshotEmitCount returns the number of times the manager has emitted a
+// snapshot for rule changes since process start.
+func (m *Manager) SnapshotEmitCount() int64 {
+	return m.snapshotEmitCount.Load()
+}
+
+type ruleSetSnapshotTarget struct {
+	gitDest types.ResourceReference
+	hash    uint64
 }
 
 const (
@@ -640,7 +671,11 @@ func (m *Manager) ReconcileForRuleChange(ctx context.Context) error {
 
 	// Compute desired GVRs from current rules
 	requestedGVRs := m.ComputeRequestedGVRs()
-	discoverableGVRs := m.FilterDiscoverableGVRs(ctx, requestedGVRs)
+	filter := m.FilterDiscoverableGVRs
+	if m.discoveryFilter != nil {
+		filter = m.discoveryFilter
+	}
+	discoverableGVRs := filter(ctx, requestedGVRs)
 
 	log.V(1).Info("Computed GVRs for reconciliation",
 		"requested", len(requestedGVRs),
@@ -657,7 +692,8 @@ func (m *Manager) ReconcileForRuleChange(ctx context.Context) error {
 	activeCount := len(m.activeInformers)
 	m.informersMu.Unlock()
 
-	if len(added) == 0 && len(removed) == 0 {
+	targets := m.snapshotTargetsNeedingDelivery(len(added) > 0 || len(removed) > 0)
+	if len(added) == 0 && len(removed) == 0 && len(targets) == 0 {
 		log.V(1).Info("No GVR changes detected, skipping reconciliation",
 			"activeGVRs", activeCount)
 		return nil
@@ -676,7 +712,7 @@ func (m *Manager) ReconcileForRuleChange(ctx context.Context) error {
 	// Put affected GitTarget event streams into RECONCILING state BEFORE starting new
 	// informers.  This ensures informer ADDED events fired during cache sync are buffered
 	// rather than processed as N individual [CREATE] commits.
-	m.beginReconciliationForAffectedTargets(log)
+	m.beginReconciliationForTargets(targets, log)
 
 	// Start informers for added GVRs
 	if len(added) > 0 {
@@ -692,14 +728,14 @@ func (m *Manager) ReconcileForRuleChange(ctx context.Context) error {
 	// Emit RequestClusterState for each affected GitTarget so that a single
 	// "reconcile: sync N resources" commit is produced instead of N individual
 	// [CREATE] commits from the informer ADDED events buffered above.
-	m.emitSnapshotForRuleChange(ctx, log)
+	m.emitSnapshotForRuleChange(ctx, log, targets)
 
 	// Transition streams back to LIVE_PROCESSING and flush buffered events.
 	// startInformersForGVRs already waited for cache sync (WaitForCacheSync),
 	// so all initial ADDED events are guaranteed to be buffered before this point.
 	// The flushed events are no-ops at the git level because the snapshot batch
 	// just wrote those files.
-	m.completeReconciliationForAffectedTargets(log)
+	m.completeReconciliationForTargets(targets, log)
 
 	log.V(1).Info("Watch manager reconciliation completed",
 		"addedGVRs", len(added),
@@ -1216,88 +1252,212 @@ func splitResourceKey(key string) []string {
 	return parts
 }
 
-// collectAffectedGitTargets returns the unique set of GitTarget ResourceReferences
-// that appear in any current WatchRule or ClusterWatchRule.
-func (m *Manager) collectAffectedGitTargets() []types.ResourceReference {
-	seen := make(map[string]struct{})
-	var targets []types.ResourceReference
+func (m *Manager) snapshotTargetsNeedingDelivery(force bool) []ruleSetSnapshotTarget {
+	current := m.currentRuleSetSnapshots()
+	currentKeys := make(map[string]struct{}, len(current))
 
-	for _, rule := range m.RuleStore.SnapshotWatchRules() {
-		ref := types.NewResourceReference(rule.GitTargetRef, rule.GitTargetNamespace)
-		if _, exists := seen[ref.Key()]; !exists {
-			seen[ref.Key()] = struct{}{}
-			targets = append(targets, ref)
+	m.ruleSetSnapshotMu.Lock()
+	defer m.ruleSetSnapshotMu.Unlock()
+	m.ensureRuleSetSnapshotMapsLocked()
+
+	var targets []ruleSetSnapshotTarget
+	for _, target := range current {
+		key := target.gitDest.Key()
+		currentKeys[key] = struct{}{}
+		if !force {
+			if lastDelivered, ok := m.lastDeliveredRuleSetHash[key]; ok && lastDelivered == target.hash {
+				continue
+			}
 		}
+		m.pendingRuleSetHash[key] = target.hash
+		targets = append(targets, target)
 	}
 
-	for _, rule := range m.RuleStore.SnapshotClusterWatchRules() {
-		ref := types.NewResourceReference(rule.GitTargetRef, rule.GitTargetNamespace)
-		if _, exists := seen[ref.Key()]; !exists {
-			seen[ref.Key()] = struct{}{}
-			targets = append(targets, ref)
+	for key := range m.lastDeliveredRuleSetHash {
+		if _, ok := currentKeys[key]; !ok {
+			delete(m.lastDeliveredRuleSetHash, key)
+			delete(m.pendingRuleSetHash, key)
+		}
+	}
+	for key := range m.pendingRuleSetHash {
+		if _, ok := currentKeys[key]; !ok {
+			delete(m.pendingRuleSetHash, key)
 		}
 	}
 
 	return targets
 }
 
-// beginReconciliationForAffectedTargets puts every registered GitTargetEventStream for
-// affected GitTargets into RECONCILING state so that informer ADDED events that fire
-// during cache sync are buffered rather than processed as individual live commits.
-func (m *Manager) beginReconciliationForAffectedTargets(log logr.Logger) {
+func (m *Manager) currentRuleSetSnapshots() []ruleSetSnapshotTarget {
+	entriesByTarget := make(map[string][]string)
+	refsByTarget := make(map[string]types.ResourceReference)
+
+	for _, rule := range m.RuleStore.SnapshotWatchRules() {
+		ref := types.NewResourceReference(rule.GitTargetRef, rule.GitTargetNamespace)
+		key := ref.Key()
+		refsByTarget[key] = ref
+		entriesByTarget[key] = append(entriesByTarget[key], fmt.Sprintf(
+			"watch|source=%s/%s|target=%s/%s|provider=%s/%s|branch=%q|path=%q|rules=%#v",
+			rule.Source.Namespace,
+			rule.Source.Name,
+			rule.GitTargetNamespace,
+			rule.GitTargetRef,
+			rule.GitProviderNamespace,
+			rule.GitProviderRef,
+			rule.Branch,
+			rule.Path,
+			rule.ResourceRules,
+		))
+	}
+
+	for _, rule := range m.RuleStore.SnapshotClusterWatchRules() {
+		ref := types.NewResourceReference(rule.GitTargetRef, rule.GitTargetNamespace)
+		key := ref.Key()
+		refsByTarget[key] = ref
+		entriesByTarget[key] = append(entriesByTarget[key], fmt.Sprintf(
+			"cluster|source=%s|target=%s/%s|provider=%s/%s|branch=%q|path=%q|rules=%#v",
+			rule.Source.Name,
+			rule.GitTargetNamespace,
+			rule.GitTargetRef,
+			rule.GitProviderNamespace,
+			rule.GitProviderRef,
+			rule.Branch,
+			rule.Path,
+			rule.Rules,
+		))
+	}
+
+	keys := make([]string, 0, len(entriesByTarget))
+	for key := range entriesByTarget {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	targets := make([]ruleSetSnapshotTarget, 0, len(keys))
+	for _, key := range keys {
+		entries := entriesByTarget[key]
+		sort.Strings(entries)
+		targets = append(targets, ruleSetSnapshotTarget{
+			gitDest: refsByTarget[key],
+			hash:    xxhash.Sum64String(strings.Join(entries, "\x00")),
+		})
+	}
+	return targets
+}
+
+func (m *Manager) ensureRuleSetSnapshotMapsLocked() {
+	if m.lastDeliveredRuleSetHash == nil {
+		m.lastDeliveredRuleSetHash = make(map[string]uint64)
+	}
+	if m.pendingRuleSetHash == nil {
+		m.pendingRuleSetHash = make(map[string]uint64)
+	}
+}
+
+func (m *Manager) markRuleSetSnapshotDelivered(target ruleSetSnapshotTarget) {
+	key := target.gitDest.Key()
+	m.ruleSetSnapshotMu.Lock()
+	defer m.ruleSetSnapshotMu.Unlock()
+	m.ensureRuleSetSnapshotMapsLocked()
+	m.lastDeliveredRuleSetHash[key] = target.hash
+	if pending, ok := m.pendingRuleSetHash[key]; ok && pending == target.hash {
+		delete(m.pendingRuleSetHash, key)
+	}
+}
+
+// MaybeReplaySnapshot emits a pending rule-change snapshot once a FolderReconciler
+// exists for gitDest. It is called by ReconcilerManager when a reconciler is created.
+func (m *Manager) MaybeReplaySnapshot(gitDest types.ResourceReference) {
+	if m == nil {
+		return
+	}
+
+	key := gitDest.Key()
+	m.ruleSetSnapshotMu.Lock()
+	m.ensureRuleSetSnapshotMapsLocked()
+	hash, pending := m.pendingRuleSetHash[key]
+	lastDelivered := m.lastDeliveredRuleSetHash[key]
+	m.ruleSetSnapshotMu.Unlock()
+
+	if !pending || lastDelivered == hash || m.EventRouter == nil {
+		return
+	}
+
+	target := ruleSetSnapshotTarget{gitDest: gitDest, hash: hash}
+	log := m.Log.WithName("reconcile")
+	m.EventRouter.BeginReconciliationForStream(gitDest)
+	m.emitSnapshotForRuleChange(context.Background(), log, []ruleSetSnapshotTarget{target})
+	m.EventRouter.CompleteReconciliationForStream(gitDest)
+}
+
+func (m *Manager) beginReconciliationForTargets(targets []ruleSetSnapshotTarget, log logr.Logger) {
 	if m.EventRouter == nil {
 		return
 	}
-	for _, gitDest := range m.collectAffectedGitTargets() {
-		m.EventRouter.BeginReconciliationForStream(gitDest)
-		log.Info("Buffering live events for snapshot", "gitDest", gitDest.String())
+	for _, target := range targets {
+		m.EventRouter.BeginReconciliationForStream(target.gitDest)
+		log.Info("Buffering live events for snapshot", "gitDest", target.gitDest.String())
 	}
 }
 
 // emitSnapshotForRuleChange emits fresh repo and cluster state requests for every affected
 // GitTarget so FolderReconciler diffs against current repository contents rather than a
 // stale cached repo snapshot from an earlier reconcile.
-func (m *Manager) emitSnapshotForRuleChange(ctx context.Context, log logr.Logger) {
+func (m *Manager) emitSnapshotForRuleChange(
+	ctx context.Context,
+	log logr.Logger,
+	targets []ruleSetSnapshotTarget,
+) {
 	if m.EventRouter == nil {
 		log.Info("EventRouter not set, skipping snapshot emission")
+		if len(targets) > 0 {
+			m.snapshotEmitCount.Add(1)
+		}
 		return
 	}
-	targets := m.collectAffectedGitTargets()
 	log.Info("Emitting fresh repo and cluster state for affected GitTargets after rule change", "count", len(targets))
-	for _, gitDest := range targets {
-		if m.EventRouter != nil && m.EventRouter.ReconcilerManager != nil {
-			if reconciler, exists := m.EventRouter.ReconcilerManager.GetReconciler(gitDest); exists {
-				reconciler.ResetState()
-			}
+	emitted := false
+	for _, target := range targets {
+		gitDest := target.gitDest
+		if m.EventRouter.ReconcilerManager == nil {
+			log.V(1).Info("ReconcilerManager not set, leaving snapshot pending", "gitDest", gitDest.String())
+			continue
 		}
+		reconciler, exists := m.EventRouter.ReconcilerManager.GetReconciler(gitDest)
+		if !exists {
+			log.V(1).Info("No reconciler registered, leaving snapshot pending", "gitDest", gitDest.String())
+			continue
+		}
+		reconciler.ResetState()
 		if err := m.EventRouter.ProcessControlEvent(ctx, events.ControlEvent{
 			Type:    events.RequestRepoState,
 			GitDest: gitDest,
 		}); err != nil {
 			log.Error(err, "failed to emit RequestRepoState for rule change", "gitDest", gitDest)
+			continue
 		}
 		if err := m.EventRouter.ProcessControlEvent(ctx, events.ControlEvent{
 			Type:    events.RequestClusterState,
 			GitDest: gitDest,
 		}); err != nil {
 			log.Error(err, "failed to emit RequestClusterState for rule change", "gitDest", gitDest)
+			continue
 		}
+		m.markRuleSetSnapshotDelivered(target)
+		emitted = true
+	}
+	if emitted {
+		m.snapshotEmitCount.Add(1)
 	}
 }
 
-// completeReconciliationForAffectedTargets transitions every affected GitTargetEventStream
-// out of RECONCILING state and flushes buffered live events.  It must be called after
-// emitSnapshotForRuleChange so that:
-//  1. The snapshot batch has already been emitted.
-//  2. Buffered informer ADDED events are flushed and produce no-op git writes (the
-//     files were just written by the snapshot).
-func (m *Manager) completeReconciliationForAffectedTargets(log logr.Logger) {
+func (m *Manager) completeReconciliationForTargets(targets []ruleSetSnapshotTarget, log logr.Logger) {
 	if m.EventRouter == nil {
 		return
 	}
-	for _, gitDest := range m.collectAffectedGitTargets() {
-		m.EventRouter.CompleteReconciliationForStream(gitDest)
-		log.Info("Flushing buffered events after snapshot", "gitDest", gitDest.String())
+	for _, target := range targets {
+		m.EventRouter.CompleteReconciliationForStream(target.gitDest)
+		log.Info("Flushing buffered events after snapshot", "gitDest", target.gitDest.String())
 	}
 }
 

--- a/internal/watch/rule_change_snapshot_test.go
+++ b/internal/watch/rule_change_snapshot_test.go
@@ -1,0 +1,370 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright 2025 ConfigButler
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watch
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	configv1alpha1 "github.com/ConfigButler/gitops-reverser/api/v1alpha1"
+	"github.com/ConfigButler/gitops-reverser/internal/git"
+	"github.com/ConfigButler/gitops-reverser/internal/reconcile"
+	"github.com/ConfigButler/gitops-reverser/internal/rulestore"
+)
+
+// These tests target a specific gap discovered in issue #146-style symptoms:
+// when a new ClusterWatchRule lands but its referenced GVR is *already* being
+// watched (e.g. because another rule already covers that GVR), today's
+// ReconcileForRuleChange takes the early-return at manager.go:660 and emits no
+// snapshot. The newly-selected resources that already exist in the cluster stay
+// out of git until they're next touched.
+//
+// Both tests assert the desired contract (snapshot count goes up when the
+// rule-set changes, regardless of whether GVRs changed) and therefore FAIL
+// today. Once the early-return is replaced with a rule-set-aware decision, the
+// tests will go green.
+
+// makeRuleChangeTestManager constructs a Manager configured for these tests:
+// fake controller-runtime client, real RuleStore, a discoveryFilter stub that
+// passes every requested GVR through (bypassing the real discovery client,
+// which is unavailable without a REST config), and a target GitTarget already
+// in the fake client.
+//
+// The configmaps GVR is also pre-populated in activeInformers with a no-op
+// cancel so compareGVRs sees the GVR as "already watched". This is the
+// steady-state we want to model: an informer for that GVR is logically
+// running, so adding a second rule for it should not cause an informer churn,
+// but *should* re-trigger a snapshot.
+func makeRuleChangeTestManager(t *testing.T) (*Manager, *rulestore.RuleStore) {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	require.NoError(t, configv1alpha1.AddToScheme(scheme))
+
+	gitTarget := &configv1alpha1.GitTarget{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-target", Namespace: "test-ns"},
+		Spec: configv1alpha1.GitTargetSpec{
+			ProviderRef: configv1alpha1.GitProviderReference{Name: "test-provider"},
+			Branch:      "main",
+			Path:        "test-path",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(gitTarget).
+		Build()
+
+	store := rulestore.NewStore()
+	configMapGVR := GVR{
+		Group:    "",
+		Version:  "v1",
+		Resource: "configmaps",
+		Scope:    configv1alpha1.ResourceScopeNamespaced,
+	}
+	manager := &Manager{
+		Client:    fakeClient,
+		Log:       logr.Discard(),
+		RuleStore: store,
+		// Pass requested GVRs through unchanged; bypasses the real discovery
+		// client which returns nil in unit tests (no REST config).
+		discoveryFilter: func(_ context.Context, in []GVR) []GVR { return in },
+		// Pretend the configmaps informer is already running cluster-wide,
+		// so compareGVRs reports added=0, removed=0 for that GVR. No real
+		// informers are started.
+		activeInformers: map[GVR]map[string]context.CancelFunc{
+			configMapGVR: {"": func() {}},
+		},
+	}
+
+	return manager, store
+}
+
+// configMapRuleForTarget builds a ClusterWatchRule that selects core/v1
+// configmaps, scoped at the given GitTarget (always in the shared "test-ns"
+// namespace used across these tests).
+func configMapRuleForTarget(name, gitTargetName string) configv1alpha1.ClusterWatchRule {
+	return configv1alpha1.ClusterWatchRule{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: configv1alpha1.ClusterWatchRuleSpec{
+			TargetRef: configv1alpha1.NamespacedTargetReference{
+				Name:      gitTargetName,
+				Namespace: "test-ns",
+			},
+			Rules: []configv1alpha1.ClusterResourceRule{{
+				APIGroups:   []string{""},
+				APIVersions: []string{"v1"},
+				Resources:   []string{"configmaps"},
+				Scope:       configv1alpha1.ResourceScopeNamespaced,
+			}},
+		},
+	}
+}
+
+// TestReconcileForRuleChange_AddingSecondRuleSameGVR_EmitsSnapshot exercises
+// the central gap. After the first rule is registered and reconciled, the
+// informer set is steady-state. Adding a *second* rule that names the same GVR
+// does not change the GVR set — only the rule-set changes. The current code
+// takes the GVR-only diff at manager.go:660 and skips the snapshot path, so
+// resources that already match the new rule are never written until their next
+// update event. The desired behavior: any rule-set change must emit a snapshot
+// for affected GitTargets.
+func TestReconcileForRuleChange_AddingSecondRuleSameGVR_EmitsSnapshot(t *testing.T) {
+	manager, store := makeRuleChangeTestManager(t)
+	ctx := context.Background()
+
+	// First rule: register, reconcile once. This brings the manager into a
+	// stable state where the configmaps informer is logically active.
+	store.AddOrUpdateClusterWatchRule(
+		configMapRuleForTarget("rule-1", "test-target"),
+		"test-target", "test-ns",
+		"test-provider", "test-ns",
+		"main", "test-path",
+	)
+	require.NoError(t, manager.ReconcileForRuleChange(ctx))
+
+	// Reset counter so the assertion targets only the *second* reconcile.
+	manager.snapshotEmitCount.Store(0)
+
+	// Second rule for the same GVR. Production today: GVR diff is empty,
+	// ReconcileForRuleChange early-returns, snapshot is never emitted.
+	store.AddOrUpdateClusterWatchRule(
+		configMapRuleForTarget("rule-2", "test-target"),
+		"test-target", "test-ns",
+		"test-provider", "test-ns",
+		"main", "test-path",
+	)
+	require.NoError(t, manager.ReconcileForRuleChange(ctx))
+
+	assert.Positive(t,
+		manager.SnapshotEmitCount(),
+		"adding a ClusterWatchRule should emit a snapshot even when no new GVR is introduced; "+
+			"existing matching resources must be backfilled to git")
+}
+
+// TestReconcileForRuleChange_NarrowingSelectorOnExistingRule_EmitsSnapshot
+// covers a sibling gap: editing a rule's selectors without changing its GVR.
+// A common operator action is "I added a label selector to my existing rule to
+// scope it down" — the GVR set does not change, but the matched resource set
+// does. Same root cause as the test above. Uses a distinct GitTarget name
+// from the prior test so the same helper exercises more than one input.
+func TestReconcileForRuleChange_NarrowingSelectorOnExistingRule_EmitsSnapshot(t *testing.T) {
+	manager, store := makeRuleChangeTestManager(t)
+	ctx := context.Background()
+
+	// Initial rule: selects all configmaps via narrow-target.
+	initial := configMapRuleForTarget("rule-1", "narrow-target")
+	store.AddOrUpdateClusterWatchRule(
+		initial,
+		"narrow-target", "test-ns",
+		"test-provider", "test-ns",
+		"main", "test-path",
+	)
+	require.NoError(t, manager.ReconcileForRuleChange(ctx))
+
+	manager.snapshotEmitCount.Store(0)
+
+	// Edit the rule — narrow its selectors. The GVR (core/v1/configmaps) is
+	// unchanged; only the rule body changes.
+	narrowed := initial
+	narrowed.Spec.Rules[0].Operations = []configv1alpha1.OperationType{
+		configv1alpha1.OperationUpdate,
+	}
+	store.AddOrUpdateClusterWatchRule(
+		narrowed,
+		"narrow-target", "test-ns",
+		"test-provider", "test-ns",
+		"main", "test-path",
+	)
+	require.NoError(t, manager.ReconcileForRuleChange(ctx))
+
+	assert.Positive(t,
+		manager.SnapshotEmitCount(),
+		"editing a ClusterWatchRule should emit a snapshot when the matched resource set may change, "+
+			"even if the GVR set is unchanged")
+}
+
+// watchRuleForTarget builds a namespaced WatchRule selecting core/v1
+// configmaps in the target's namespace.
+func watchRuleForTarget(name, gitTargetName, namespace string) configv1alpha1.WatchRule {
+	return configv1alpha1.WatchRule{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: configv1alpha1.WatchRuleSpec{
+			TargetRef: configv1alpha1.LocalTargetReference{Name: gitTargetName},
+			Rules: []configv1alpha1.ResourceRule{{
+				APIGroups:   []string{""},
+				APIVersions: []string{"v1"},
+				Resources:   []string{"configmaps"},
+			}},
+		},
+	}
+}
+
+// TestReconcileForRuleChange_AddingSecondWatchRuleSameGVR_EmitsSnapshot is the
+// namespaced-WatchRule analogue of the ClusterWatchRule test above. The
+// underlying code path is the same (rules feed into ComputeRequestedGVRs and
+// collectAffectedGitTargets via the shared RuleStore), so the same gap
+// applies. Documenting it as a separate test makes the regression coverage
+// for both rule kinds explicit.
+func TestReconcileForRuleChange_AddingSecondWatchRuleSameGVR_EmitsSnapshot(t *testing.T) {
+	manager, store := makeRuleChangeTestManager(t)
+	ctx := context.Background()
+
+	store.AddOrUpdateWatchRule(
+		watchRuleForTarget("rule-1", "test-target", "test-ns"),
+		"test-target", "test-ns",
+		"test-provider", "test-ns",
+		"main", "test-path",
+	)
+	require.NoError(t, manager.ReconcileForRuleChange(ctx))
+
+	manager.snapshotEmitCount.Store(0)
+
+	store.AddOrUpdateWatchRule(
+		watchRuleForTarget("rule-2", "test-target", "test-ns"),
+		"test-target", "test-ns",
+		"test-provider", "test-ns",
+		"main", "test-path",
+	)
+	require.NoError(t, manager.ReconcileForRuleChange(ctx))
+
+	assert.Positive(t,
+		manager.SnapshotEmitCount(),
+		"adding a second WatchRule should emit a snapshot even when no new GVR is introduced; "+
+			"the bug is symmetric across WatchRule and ClusterWatchRule")
+}
+
+// TestReconcileForRuleChange_RestartLikeBootstrap_NoSnapshotDrops models the
+// "restart with already-Ready GitTarget" scenario. The user-visible symptom:
+//
+//   - On controller restart, GitTarget.Status.SnapshotSynced is already True
+//     from the prior run, so GitTargetReconciler takes the early-return at
+//     gittarget_controller.go:384 and creates no FolderReconciler.
+//   - WatchManager.Start runs its initial ReconcileForRuleChange before the
+//     GitTargetReconciler reaches the target, so the snapshot is emitted
+//     while no reconciler is registered. RouteClusterStateEvent / RouteRepoStateEvent
+//     find no receiver and silently drop the snapshot output.
+//   - Live update events still flow through (informer is running, the eventual
+//     stream registration brings it to LiveProcessing), so the user sees
+//     "updates write, but pre-existing resources never land in git."
+//
+// This test reproduces the drop by emitting a snapshot with no pre-registered
+// FolderReconciler and asserting the drop counter stays at zero. Today it
+// fails because the snapshot fires unconditionally without coordination with
+// the GitTargetReconciler.
+//
+// The setup populates activeInformers with a stale GVR and uses a
+// discoveryFilter that returns no GVRs, so compareGVRs reports
+// added=[], removed=[stale-gvr]. That bypasses the early-return without
+// requiring any real informers to start.
+func TestReconcileForRuleChange_RestartLikeBootstrap_NoSnapshotDrops(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	require.NoError(t, configv1alpha1.AddToScheme(scheme))
+
+	gitTarget := &configv1alpha1.GitTarget{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-target", Namespace: "test-ns"},
+		Spec: configv1alpha1.GitTargetSpec{
+			ProviderRef: configv1alpha1.GitProviderReference{Name: "test-provider"},
+			Branch:      "main",
+			Path:        "test-path",
+		},
+		Status: configv1alpha1.GitTargetStatus{
+			Conditions: []metav1.Condition{
+				// Simulate the post-restart state that triggers the
+				// gittarget_controller.go:384 early-return.
+				{Type: "SnapshotSynced", Status: metav1.ConditionTrue, Reason: "Completed"},
+			},
+		},
+	}
+	preexistingCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "preexisting", Namespace: "test-ns"},
+	}
+
+	fakeK8s := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(gitTarget).
+		Build()
+
+	store := rulestore.NewStore()
+	store.AddOrUpdateClusterWatchRule(
+		configMapRuleForTarget("rule-1", "test-target"),
+		"test-target", "test-ns",
+		"test-provider", "test-ns",
+		"main", "test-path",
+	)
+
+	staleGVR := GVR{
+		Group: "apps", Version: "v1", Resource: "deployments",
+		Scope: configv1alpha1.ResourceScopeNamespaced,
+	}
+	manager := &Manager{
+		Client:        fakeK8s,
+		Log:           logr.Discard(),
+		RuleStore:     store,
+		dynamicClient: dynamicfake.NewSimpleDynamicClient(scheme, preexistingCM),
+		// Return no discoverable GVRs so the rule's GVR (configmaps) doesn't
+		// hit startInformersForGVRs. Combined with a stale entry in
+		// activeInformers, compareGVRs reports removed > 0 and the
+		// snapshot-emit path runs.
+		discoveryFilter: func(_ context.Context, _ []GVR) []GVR { return nil },
+		activeInformers: map[GVR]map[string]context.CancelFunc{
+			staleGVR: {"": func() {}},
+		},
+	}
+
+	// Wire EventRouter with empty-but-non-nil sub-components. This is the
+	// state immediately after WatchManager.Start: workers and reconcilers
+	// have not yet been registered by their respective controllers.
+	manager.EventRouter = &EventRouter{
+		WorkerManager:     git.NewWorkerManager(fakeK8s, logr.Discard(), 0),
+		ReconcilerManager: reconcile.NewReconcilerManager(nil, logr.Discard()),
+		WatchManager:      manager,
+		Client:            fakeK8s,
+		Log:               logr.Discard(),
+		gitTargetStreams:  map[string]*reconcile.GitTargetEventStream{},
+	}
+
+	require.NoError(t, manager.ReconcileForRuleChange(ctx()))
+
+	assert.Zero(t,
+		manager.EventRouter.SnapshotDeliveryDrops(),
+		"on a restart-like bootstrap (no FolderReconciler registered yet), the snapshot is emitted "+
+			"but RouteClusterStateEvent/RouteRepoStateEvent silently drop it; the system must coordinate "+
+			"emission with reconciler registration, or retry, so pre-existing matching resources land in git")
+}
+
+// ctx returns a background context. Wrapped for terse use in test setup.
+func ctx() context.Context { return context.Background() }
+
+// Compile-time sanity: corev1 is used by tests that may extend this file with
+// pre-populated ConfigMap objects to assert backfill content. Today only the
+// snapshot-emit counter is asserted; keep the import for cheap follow-up tests.
+var _ = corev1.ConfigMap{}

--- a/internal/webhook/audit_handler.go
+++ b/internal/webhook/audit_handler.go
@@ -28,6 +28,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/go-logr/logr"
 	"go.opentelemetry.io/otel/attribute"
@@ -89,6 +90,7 @@ type AuditHandler struct {
 	deserializer runtime.Decoder
 	config       AuditHandlerConfig
 	firsts       auditHandlerFirsts
+	canonicalMu  sync.Mutex
 }
 
 // NewAuditHandler creates a new audit handler with the given configuration.
@@ -216,6 +218,13 @@ func (h *AuditHandler) processEvent(ctx context.Context, source AuditSource, aud
 	// same auditID would be dropped as a duplicate before reaching Git.
 	if auditEventV1.Stage != auditv1.StageResponseComplete {
 		return nil
+	}
+
+	if source == AuditSourceOfficial {
+		gateStart := time.Now()
+		h.canonicalMu.Lock()
+		defer h.canonicalMu.Unlock()
+		observeOfficialGateWait(ctx, time.Since(gateStart).Seconds())
 	}
 
 	quality := classifyAuditEventQuality(source, &auditEventV1)

--- a/internal/webhook/audit_handler_test.go
+++ b/internal/webhook/audit_handler_test.go
@@ -23,11 +23,14 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -48,12 +51,26 @@ func (q errorAuditEventQueue) Enqueue(_ context.Context, _ auditv1.Event) error 
 }
 
 type recordingAuditEventQueue struct {
+	mu     sync.Mutex
 	events []auditv1.Event
 }
 
 func (q *recordingAuditEventQueue) Enqueue(_ context.Context, event auditv1.Event) error {
+	q.mu.Lock()
+	defer q.mu.Unlock()
 	q.events = append(q.events, event)
 	return nil
+}
+
+func (q *recordingAuditEventQueue) auditIDs() []string {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	ids := make([]string, 0, len(q.events))
+	for _, event := range q.events {
+		ids = append(ids, string(event.AuditID))
+	}
+	return ids
 }
 
 type fakeAuditJoiner struct {
@@ -89,6 +106,63 @@ func (j *fakeAuditJoiner) CommitDecision(_ context.Context, _ string, result Aud
 
 func (j *fakeAuditJoiner) ReleaseDecision(_ context.Context, auditID string) error {
 	j.releases = append(j.releases, auditID)
+	return nil
+}
+
+type orderingAuditJoiner struct {
+	firstStarted        chan struct{}
+	releaseFirst        chan struct{}
+	additionalProcessed chan struct{}
+	closeFirstStarted   sync.Once
+	closeAdditional     sync.Once
+}
+
+func newOrderingAuditJoiner() *orderingAuditJoiner {
+	return &orderingAuditJoiner{
+		firstStarted:        make(chan struct{}),
+		releaseFirst:        make(chan struct{}),
+		additionalProcessed: make(chan struct{}),
+	}
+}
+
+func (j *orderingAuditJoiner) Decide(
+	ctx context.Context,
+	source AuditSource,
+	event *auditv1.Event,
+	_ AuditEventQuality,
+) (AuditJoinDecision, error) {
+	if source == AuditSourceAdditional {
+		j.closeAdditional.Do(func() {
+			close(j.additionalProcessed)
+		})
+		return AuditJoinDecision{Action: AuditJoinActionParked}, nil
+	}
+
+	if string(event.AuditID) == "first" {
+		j.closeFirstStarted.Do(func() {
+			close(j.firstStarted)
+		})
+		select {
+		case <-ctx.Done():
+			return AuditJoinDecision{}, ctx.Err()
+		case <-j.releaseFirst:
+		}
+	}
+
+	return AuditJoinDecision{
+		Action:  AuditJoinActionEmit,
+		Event:   event,
+		AuditID: string(event.AuditID),
+		Result:  AuditJoinResultAsIs,
+		Source:  AuditSourceOfficial,
+	}, nil
+}
+
+func (j *orderingAuditJoiner) CommitDecision(_ context.Context, _ string, _ AuditJoinResult) error {
+	return nil
+}
+
+func (j *orderingAuditJoiner) ReleaseDecision(_ context.Context, _ string) error {
 	return nil
 }
 
@@ -600,6 +674,83 @@ func TestAuditHandler_JoinerParkedSkipsQueue(t *testing.T) {
 	assert.Empty(t, queue.events)
 	assert.Empty(t, joiner.commits)
 	assert.Empty(t, joiner.releases)
+}
+
+func TestAuditHandler_OfficialCanonicalEventsAreOrderedWhileAdditionalCanPark(t *testing.T) {
+	queue := &recordingAuditEventQueue{}
+	joiner := newOrderingAuditJoiner()
+	handler, err := NewAuditHandler(AuditHandlerConfig{
+		Queue:  queue,
+		Joiner: joiner,
+	})
+	require.NoError(t, err)
+
+	serve := func(path, auditID string) *httptest.ResponseRecorder {
+		t.Helper()
+		body := fmt.Sprintf(
+			`{"kind":"EventList","apiVersion":"audit.k8s.io/v1","items":[`+
+				`{"kind":"Event","auditID":%q,"verb":"create","stage":"ResponseComplete",`+
+				`"user":{"username":"test-user"},"objectRef":{"resource":"flunders",`+
+				`"apiGroup":"wardle.example.com","apiVersion":"v1alpha1"}}]}`,
+			auditID,
+		)
+		req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader([]byte(body)))
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		return w
+	}
+
+	firstDone := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		firstDone <- serve("/audit-webhook", "first")
+	}()
+
+	select {
+	case <-joiner.firstStarted:
+	case <-time.After(time.Second):
+		t.Fatal("first official event did not enter the joiner")
+	}
+
+	secondDone := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		secondDone <- serve("/audit-webhook", "second")
+	}()
+
+	additionalDone := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		additionalDone <- serve("/audit-webhook-additional", "first")
+	}()
+
+	select {
+	case w := <-additionalDone:
+		require.Equal(t, http.StatusOK, w.Code)
+	case <-time.After(time.Second):
+		t.Fatal("additional audit body should be able to park while the official event is waiting")
+	}
+
+	select {
+	case <-secondDone:
+		t.Fatal("second official event overtook the blocked first official event")
+	case <-time.After(50 * time.Millisecond):
+	}
+	assert.Empty(t, queue.auditIDs())
+
+	close(joiner.releaseFirst)
+
+	select {
+	case w := <-firstDone:
+		require.Equal(t, http.StatusOK, w.Code)
+	case <-time.After(time.Second):
+		t.Fatal("first official event did not finish")
+	}
+	select {
+	case w := <-secondDone:
+		require.Equal(t, http.StatusOK, w.Code)
+	case <-time.After(time.Second):
+		t.Fatal("second official event did not finish")
+	}
+
+	assert.Equal(t, []string{"first", "second"}, queue.auditIDs())
 }
 
 func TestAuditHandler_JoinerReleasesDecisionOnEnqueueFailure(t *testing.T) {

--- a/internal/webhook/audit_joiner.go
+++ b/internal/webhook/audit_joiner.go
@@ -46,6 +46,8 @@ type auditJoinerFirsts struct {
 	malformedAdditional  sync.Once
 	additionalBodyParked sync.Once
 	mergedEmit           sync.Once
+	officialWaitMerged   sync.Once
+	officialWaitTimedOut sync.Once
 }
 
 const (
@@ -56,6 +58,7 @@ const (
 
 	defaultAuditEventBodyTTL     = 5 * time.Minute
 	defaultAuditEventDecisionTTL = time.Hour
+	auditJoinBodyPollInterval    = 25 * time.Millisecond
 )
 
 // AuditSource is the semantic source role of an audit webhook endpoint.
@@ -146,22 +149,24 @@ type auditDecisionEnvelope struct {
 
 // RedisAuditJoinerConfig configures Redis-backed audit body parking and decision tracking.
 type RedisAuditJoinerConfig struct {
-	Addr        string
-	Username    string
-	AuthValue   string
-	DB          int
-	TLSEnabled  bool
-	BodyTTL     time.Duration
-	DecisionTTL time.Duration
+	Addr             string
+	Username         string
+	AuthValue        string
+	DB               int
+	TLSEnabled       bool
+	BodyTTL          time.Duration
+	DecisionTTL      time.Duration
+	OfficialBodyWait time.Duration
 }
 
 // RedisAuditEventJoiner implements audit body parking with Redis/Valkey keys.
 type RedisAuditEventJoiner struct {
-	client      *redis.Client
-	bodyTTL     time.Duration
-	decisionTTL time.Duration
-	now         func() time.Time
-	firsts      auditJoinerFirsts
+	client           *redis.Client
+	bodyTTL          time.Duration
+	decisionTTL      time.Duration
+	officialBodyWait time.Duration
+	now              func() time.Time
+	firsts           auditJoinerFirsts
 }
 
 // NewRedisAuditEventJoiner creates a Redis-backed AuditEventJoiner.
@@ -189,16 +194,17 @@ func NewRedisAuditEventJoiner(cfg RedisAuditJoinerConfig) (*RedisAuditEventJoine
 	}
 
 	return &RedisAuditEventJoiner{
-		client:      redis.NewClient(options),
-		bodyTTL:     bodyTTL,
-		decisionTTL: decisionTTL,
-		now:         time.Now,
+		client:           redis.NewClient(options),
+		bodyTTL:          bodyTTL,
+		decisionTTL:      decisionTTL,
+		officialBodyWait: cfg.OfficialBodyWait,
+		now:              time.Now,
 	}, nil
 }
 
 // Decide examines an event and, for emitted events, claims the audit ID before enqueueing.
-// Officials never park: an identity-shallow official with no matching parked body drops
-// synchronously with audit_shallow_dropped_total + a WARN log.
+// Officials never park. An identity-shallow official with no matching parked body waits briefly
+// for an additional body contribution, then drops with audit_shallow_dropped_total if none arrives.
 func (j *RedisAuditEventJoiner) Decide(
 	ctx context.Context,
 	source AuditSource,
@@ -258,10 +264,19 @@ func (j *RedisAuditEventJoiner) handleOfficial(
 	quality AuditEventQuality,
 ) (AuditJoinDecision, error) {
 	auditID := string(event.AuditID)
+	officialArrival := j.now()
 
 	envelope, hasBody, err := j.peekBody(ctx, auditID)
 	if err != nil {
 		return AuditJoinDecision{}, err
+	}
+	bodyParkedBeforeOfficial := hasBody
+
+	if !hasBody && quality == AuditEventQualityIdentityShallow {
+		envelope, hasBody, err = j.waitForBody(ctx, auditID, event)
+		if err != nil {
+			return AuditJoinDecision{}, err
+		}
 	}
 
 	if !hasBody && quality == AuditEventQualityIdentityShallow {
@@ -303,6 +318,12 @@ func (j *RedisAuditEventJoiner) handleOfficial(
 			logf.Log.WithName("audit-joiner").
 				Error(err, "Failed to delete merged parked audit body", "auditID", auditID)
 		}
+		if bodyParkedBeforeOfficial {
+			// The additional body was already parked when the official arrived: the skew is
+			// the proxy's lead time. waitForBody records the official-first cases itself.
+			observeJoinSkew(ctx, joinArrivalBodyFirst, joinOutcomeMerged,
+				officialArrival.Sub(envelope.ReceivedAt.Time).Seconds())
+		}
 		j.firsts.mergedEmit.Do(func() {
 			logf.Log.WithName("audit-joiner").Info(
 				"First shallow-event conversion succeeded: official event merged with parked additional body",
@@ -327,6 +348,64 @@ func (j *RedisAuditEventJoiner) handleOfficial(
 		Result:  AuditJoinResultAsIs,
 		Source:  AuditSourceOfficial,
 	}, nil
+}
+
+func (j *RedisAuditEventJoiner) waitForBody(
+	ctx context.Context,
+	auditID string,
+	event *auditv1.Event,
+) (AuditBodyEnvelope, bool, error) {
+	if j.officialBodyWait <= 0 {
+		return AuditBodyEnvelope{}, false, nil
+	}
+
+	waitStart := j.now()
+	deadline := waitStart.Add(j.officialBodyWait)
+	ticker := time.NewTicker(auditJoinBodyPollInterval)
+	defer ticker.Stop()
+
+	joinerLog := logf.Log.WithName("audit-joiner")
+	joinerLog.V(1).Info("waiting briefly for additional audit body",
+		"auditID", auditID,
+		"gvr", auditEventGVR(event),
+		"verb", event.Verb,
+		"wait", j.officialBodyWait)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return AuditBodyEnvelope{}, false, ctx.Err()
+		case <-ticker.C:
+			envelope, hasBody, err := j.peekBody(ctx, auditID)
+			if err != nil {
+				return AuditBodyEnvelope{}, false, err
+			}
+			if hasBody {
+				observeJoinSkew(ctx, joinArrivalOfficialFirst, joinOutcomeMerged,
+					j.now().Sub(waitStart).Seconds())
+				j.firsts.officialWaitMerged.Do(func() {
+					joinerLog.Info("Official shallow audit event found additional body after waiting",
+						"auditID", auditID,
+						"gvr", auditEventGVR(event),
+						"verb", event.Verb,
+						"wait", j.officialBodyWait)
+				})
+				return envelope, true, nil
+			}
+			if !j.now().Before(deadline) {
+				observeJoinSkew(ctx, joinArrivalOfficialFirst, joinOutcomeTimedOut,
+					j.now().Sub(waitStart).Seconds())
+				j.firsts.officialWaitTimedOut.Do(func() {
+					joinerLog.Info("Official shallow audit event timed out waiting for additional body",
+						"auditID", auditID,
+						"gvr", auditEventGVR(event),
+						"verb", event.Verb,
+						"wait", j.officialBodyWait)
+				})
+				return AuditBodyEnvelope{}, false, nil
+			}
+		}
+	}
 }
 
 func (j *RedisAuditEventJoiner) handleAdditional(
@@ -652,4 +731,47 @@ func addBodyLateMetric(ctx context.Context, event *auditv1.Event) {
 			attribute.String("action", eventVerb(event)),
 		))
 	}
+}
+
+const (
+	// joinArrivalBodyFirst marks a join where the additional body was parked before the
+	// official event arrived (the common, healthy case).
+	joinArrivalBodyFirst = "body_first"
+	// joinArrivalOfficialFirst marks a join where the official event arrived first and had
+	// to wait on the canonical gate for the additional body.
+	joinArrivalOfficialFirst = "official_first"
+
+	// joinOutcomeMerged marks a skew sample where the official event was merged with a body.
+	joinOutcomeMerged = "merged"
+	// joinOutcomeTimedOut marks a skew sample where the wait expired before a body arrived.
+	joinOutcomeTimedOut = "timed_out"
+)
+
+// observeJoinSkew records the arrival skew between an official audit event and its matching
+// additional body. For body_first samples this is the proxy's lead time; for official_first
+// samples it is how long the official event waited on the canonical gate. Negative samples
+// (clock jitter) are clamped to zero so they land in the first bucket.
+func observeJoinSkew(ctx context.Context, arrival, outcome string, seconds float64) {
+	if telemetry.AuditJoinSkewSeconds == nil {
+		return
+	}
+	if seconds < 0 {
+		seconds = 0
+	}
+	telemetry.AuditJoinSkewSeconds.Record(ctx, seconds, metric.WithAttributes(
+		attribute.String("arrival", arrival),
+		attribute.String("outcome", outcome),
+	))
+}
+
+// observeOfficialGateWait records how long an official audit event waited to acquire the
+// in-pod canonical ordering gate before processing.
+func observeOfficialGateWait(ctx context.Context, seconds float64) {
+	if telemetry.AuditOfficialGateWaitSeconds == nil {
+		return
+	}
+	if seconds < 0 {
+		seconds = 0
+	}
+	telemetry.AuditOfficialGateWaitSeconds.Record(ctx, seconds)
 }

--- a/internal/webhook/audit_joiner.go
+++ b/internal/webhook/audit_joiner.go
@@ -28,6 +28,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/redis/go-redis/v9"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
@@ -47,7 +48,6 @@ type auditJoinerFirsts struct {
 	additionalBodyParked sync.Once
 	mergedEmit           sync.Once
 	officialWaitMerged   sync.Once
-	officialWaitTimedOut sync.Once
 }
 
 const (
@@ -166,6 +166,7 @@ type RedisAuditEventJoiner struct {
 	decisionTTL      time.Duration
 	officialBodyWait time.Duration
 	now              func() time.Time
+	logger           logr.Logger
 	firsts           auditJoinerFirsts
 }
 
@@ -199,6 +200,7 @@ func NewRedisAuditEventJoiner(cfg RedisAuditJoinerConfig) (*RedisAuditEventJoine
 		decisionTTL:      decisionTTL,
 		officialBodyWait: cfg.OfficialBodyWait,
 		now:              time.Now,
+		logger:           logf.Log.WithName("audit-joiner"),
 	}, nil
 }
 
@@ -281,7 +283,7 @@ func (j *RedisAuditEventJoiner) handleOfficial(
 
 	if !hasBody && quality == AuditEventQualityIdentityShallow {
 		addShallowDroppedMetric(ctx, event)
-		joinerLog := logf.Log.WithName("audit-joiner")
+		joinerLog := j.logger
 		j.firsts.shallowDropped.Do(func() {
 			joinerLog.Info(
 				"First shallow audit event dropped — no request/response body received. "+
@@ -315,8 +317,7 @@ func (j *RedisAuditEventJoiner) handleOfficial(
 
 	if hasBody {
 		if err := j.deleteBody(ctx, auditID); err != nil {
-			logf.Log.WithName("audit-joiner").
-				Error(err, "Failed to delete merged parked audit body", "auditID", auditID)
+			j.logger.Error(err, "Failed to delete merged parked audit body", "auditID", auditID)
 		}
 		if bodyParkedBeforeOfficial {
 			// The additional body was already parked when the official arrived: the skew is
@@ -325,7 +326,7 @@ func (j *RedisAuditEventJoiner) handleOfficial(
 				officialArrival.Sub(envelope.ReceivedAt.Time).Seconds())
 		}
 		j.firsts.mergedEmit.Do(func() {
-			logf.Log.WithName("audit-joiner").Info(
+			j.logger.Info(
 				"First shallow-event conversion succeeded: official event merged with parked additional body",
 				"auditID", auditID,
 				"gvr", auditEventGVR(event),
@@ -359,13 +360,16 @@ func (j *RedisAuditEventJoiner) waitForBody(
 		return AuditBodyEnvelope{}, false, nil
 	}
 
-	waitStart := j.now()
-	deadline := waitStart.Add(j.officialBodyWait)
+	// The body wait is an inherently real-time operation: the deadline and the
+	// skew samples must be measured from one wall clock, never from the
+	// injectable j.now() (which tests freeze). time.After owns the deadline so
+	// there is no clock comparison left to get wrong.
+	waitStart := time.Now()
 	ticker := time.NewTicker(auditJoinBodyPollInterval)
 	defer ticker.Stop()
+	timeout := time.After(j.officialBodyWait)
 
-	joinerLog := logf.Log.WithName("audit-joiner")
-	joinerLog.V(1).Info("waiting briefly for additional audit body",
+	j.logger.V(1).Info("waiting briefly for additional audit body",
 		"auditID", auditID,
 		"gvr", auditEventGVR(event),
 		"verb", event.Verb,
@@ -375,6 +379,22 @@ func (j *RedisAuditEventJoiner) waitForBody(
 		select {
 		case <-ctx.Done():
 			return AuditBodyEnvelope{}, false, ctx.Err()
+		case <-timeout:
+			observeJoinSkew(ctx, joinArrivalOfficialFirst, joinOutcomeTimedOut,
+				time.Since(waitStart).Seconds())
+			// Logged on every occurrence (deliberately not gated behind a
+			// sync.Once): a recurring timeout means the additional-body proxy
+			// is missing or lagging, and operators need that signal to persist,
+			// not just appear once at startup.
+			j.logger.Info(
+				"WARNING: official shallow audit event timed out waiting for additional body; "+
+					"the official event will be dropped. Install or repair apiservice-audit-proxy "+
+					"so request/response bodies arrive within the wait budget.",
+				"auditID", auditID,
+				"gvr", auditEventGVR(event),
+				"verb", event.Verb,
+				"wait", j.officialBodyWait)
+			return AuditBodyEnvelope{}, false, nil
 		case <-ticker.C:
 			envelope, hasBody, err := j.peekBody(ctx, auditID)
 			if err != nil {
@@ -382,27 +402,15 @@ func (j *RedisAuditEventJoiner) waitForBody(
 			}
 			if hasBody {
 				observeJoinSkew(ctx, joinArrivalOfficialFirst, joinOutcomeMerged,
-					j.now().Sub(waitStart).Seconds())
+					time.Since(waitStart).Seconds())
 				j.firsts.officialWaitMerged.Do(func() {
-					joinerLog.Info("Official shallow audit event found additional body after waiting",
+					j.logger.Info("Official shallow audit event found additional body after waiting",
 						"auditID", auditID,
 						"gvr", auditEventGVR(event),
 						"verb", event.Verb,
 						"wait", j.officialBodyWait)
 				})
 				return envelope, true, nil
-			}
-			if !j.now().Before(deadline) {
-				observeJoinSkew(ctx, joinArrivalOfficialFirst, joinOutcomeTimedOut,
-					j.now().Sub(waitStart).Seconds())
-				j.firsts.officialWaitTimedOut.Do(func() {
-					joinerLog.Info("Official shallow audit event timed out waiting for additional body",
-						"auditID", auditID,
-						"gvr", auditEventGVR(event),
-						"verb", event.Verb,
-						"wait", j.officialBodyWait)
-				})
-				return AuditBodyEnvelope{}, false, nil
 			}
 		}
 	}
@@ -414,7 +422,7 @@ func (j *RedisAuditEventJoiner) handleAdditional(
 	quality AuditEventQuality,
 ) (AuditJoinDecision, error) {
 	auditID := string(event.AuditID)
-	joinerLog := logf.Log.WithName("audit-joiner")
+	joinerLog := j.logger
 	if quality == AuditEventQualityMalformed {
 		j.firsts.malformedAdditional.Do(func() {
 			joinerLog.Info(

--- a/internal/webhook/audit_joiner_test.go
+++ b/internal/webhook/audit_joiner_test.go
@@ -22,10 +22,13 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/alicebob/miniredis/v2"
+	"github.com/go-logr/logr/funcr"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -171,6 +174,63 @@ func TestRedisAuditEventJoiner_ShallowOfficialTimesOutWaitingForBody(t *testing.
 	assert.Equal(t, AuditJoinActionDrop, decision.Action)
 	assert.False(t, mr.Exists(bodyKey("audit-wait-timeout-1")), "timed-out wait must not park")
 	assert.False(t, mr.Exists(decisionKey("audit-wait-timeout-1")), "shallow drop must not claim a decision")
+}
+
+// TestRedisAuditEventJoiner_WaitForBodyHonorsInjectedClock demonstrates PR #149
+// review issue 4: waitForBody computes its deadline from the injectable j.now()
+// but is driven by a real time.Ticker. When j.now() is frozen (or skewed), the
+// deadline check `!j.now().Before(deadline)` never becomes true, so the wait
+// loop spins until the context is cancelled instead of timing out cleanly.
+func TestRedisAuditEventJoiner_WaitForBodyHonorsInjectedClock(t *testing.T) {
+	mr := miniredis.RunT(t)
+	joiner := newTestJoinerWithOfficialBodyWait(t, mr, 100*time.Millisecond)
+
+	// Freeze the joiner clock: every j.now() call returns the same instant.
+	frozen := time.Now()
+	joiner.now = func() time.Time { return frozen }
+
+	official := testAuditEvent("audit-frozen-clock-1", "wardle.example.com", false)
+
+	// The 1s context is only a safety net so the spin does not hang the suite
+	// forever; correct behaviour must not depend on it firing.
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	decision, err := decide(ctx, t, joiner, AuditSourceOfficial, &official)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err, "wait must time out on its own deadline, not via context cancellation")
+	assert.Equal(t, AuditJoinActionDrop, decision.Action)
+	assert.Less(t, elapsed, 750*time.Millisecond,
+		"a 100ms body wait must not run until the 1s context deadline")
+}
+
+// TestRedisAuditEventJoiner_TimeoutLogsEveryOccurrence verifies PR #149 review
+// issue 1: a body-wait timeout must log on every occurrence, not just once per
+// process. A recurring timeout means the additional-body proxy is missing or
+// lagging, and operators need that signal to persist.
+func TestRedisAuditEventJoiner_TimeoutLogsEveryOccurrence(t *testing.T) {
+	mr := miniredis.RunT(t)
+	joiner := newTestJoinerWithOfficialBodyWait(t, mr, 30*time.Millisecond)
+
+	var timeoutLogs atomic.Int64
+	joiner.logger = funcr.New(func(_, args string) {
+		if strings.Contains(args, "timed out waiting for additional body") {
+			timeoutLogs.Add(1)
+		}
+	}, funcr.Options{})
+
+	ctx := context.Background()
+	for _, auditID := range []string{"audit-timeout-log-1", "audit-timeout-log-2"} {
+		official := testAuditEvent(auditID, "wardle.example.com", false)
+		decision, err := decide(ctx, t, joiner, AuditSourceOfficial, &official)
+		require.NoError(t, err)
+		require.Equal(t, AuditJoinActionDrop, decision.Action)
+	}
+
+	assert.Equal(t, int64(2), timeoutLogs.Load(),
+		"every body-wait timeout must log, not just the first")
 }
 
 func TestRedisAuditEventJoiner_WaitOfficialEmitsNamedOfficialWithoutBody(t *testing.T) {

--- a/internal/webhook/audit_joiner_test.go
+++ b/internal/webhook/audit_joiner_test.go
@@ -125,6 +125,54 @@ func TestRedisAuditEventJoiner_ShallowOfficialWithoutParkedBodyDropsImmediately(
 	assert.False(t, mr.Exists(decisionKey("audit-shallow-1")), "shallow drop must not claim a decision")
 }
 
+func TestRedisAuditEventJoiner_ShallowOfficialWaitsForLateAdditionalBody(t *testing.T) {
+	mr := miniredis.RunT(t)
+	joiner := newTestJoinerWithOfficialBodyWait(t, mr, 200*time.Millisecond)
+	ctx := context.Background()
+
+	additional := testAuditEvent("audit-late-body-1", "wardle.example.com", true)
+	official := testAuditEvent("audit-late-body-1", "wardle.example.com", false)
+
+	errCh := make(chan error, 1)
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		_, err := joiner.Decide(
+			ctx,
+			AuditSourceAdditional,
+			&additional,
+			classifyAuditEventQuality(AuditSourceAdditional, &additional),
+		)
+		errCh <- err
+	}()
+
+	decision, err := decide(ctx, t, joiner, AuditSourceOfficial, &official)
+	require.NoError(t, err)
+	require.NoError(t, <-errCh)
+
+	require.Equal(t, AuditJoinActionEmit, decision.Action)
+	require.Equal(t, AuditJoinResultMerged, decision.Result)
+	require.NotNil(t, decision.Event.RequestObject)
+	require.NotNil(t, decision.Event.ResponseObject)
+	assert.False(t, mr.Exists(bodyKey("audit-late-body-1")))
+}
+
+func TestRedisAuditEventJoiner_ShallowOfficialTimesOutWaitingForBody(t *testing.T) {
+	mr := miniredis.RunT(t)
+	joiner := newTestJoinerWithOfficialBodyWait(t, mr, 100*time.Millisecond)
+
+	official := testAuditEvent("audit-wait-timeout-1", "wardle.example.com", false)
+
+	start := time.Now()
+	decision, err := decide(context.Background(), t, joiner, AuditSourceOfficial, &official)
+	require.NoError(t, err)
+
+	assert.GreaterOrEqual(t, time.Since(start), 100*time.Millisecond,
+		"shallow official should hold the canonical gate for the full body wait before dropping")
+	assert.Equal(t, AuditJoinActionDrop, decision.Action)
+	assert.False(t, mr.Exists(bodyKey("audit-wait-timeout-1")), "timed-out wait must not park")
+	assert.False(t, mr.Exists(decisionKey("audit-wait-timeout-1")), "shallow drop must not claim a decision")
+}
+
 func TestRedisAuditEventJoiner_WaitOfficialEmitsNamedOfficialWithoutBody(t *testing.T) {
 	mr := miniredis.RunT(t)
 	joiner := newTestJoiner(t, mr)
@@ -277,10 +325,20 @@ func newTestJoiner(
 	mr *miniredis.Miniredis,
 ) *RedisAuditEventJoiner {
 	t.Helper()
+	return newTestJoinerWithOfficialBodyWait(t, mr, 0)
+}
+
+func newTestJoinerWithOfficialBodyWait(
+	t *testing.T,
+	mr *miniredis.Miniredis,
+	officialBodyWait time.Duration,
+) *RedisAuditEventJoiner {
+	t.Helper()
 	joiner, err := NewRedisAuditEventJoiner(RedisAuditJoinerConfig{
-		Addr:        mr.Addr(),
-		BodyTTL:     time.Minute,
-		DecisionTTL: time.Hour,
+		Addr:             mr.Addr(),
+		BodyTTL:          time.Minute,
+		DecisionTTL:      time.Hour,
+		OfficialBodyWait: officialBodyWait,
 	})
 	require.NoError(t, err)
 	return joiner

--- a/test/e2e/audit_helpers_test.go
+++ b/test/e2e/audit_helpers_test.go
@@ -21,8 +21,8 @@ package e2e
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/redis/go-redis/v9"
 )
@@ -88,7 +88,12 @@ func findAuditPayloadSince(
 		}
 	}
 
-	return auditPayloadEntry{}, errors.New("no matching audit payload found")
+	return auditPayloadEntry{}, fmt.Errorf(
+		"no matching audit payload found after scanning %d entries from %q: %s",
+		len(entries),
+		start,
+		summarizeAuditPayloadEntries(entries, 12),
+	)
 }
 
 func countAuditPayloadsByAuditIDSince(
@@ -163,6 +168,68 @@ func auditObjectRefName(payload map[string]interface{}) string {
 func auditPayloadHasObject(payload map[string]interface{}, field string) bool {
 	object, _ := payload[field].(map[string]interface{})
 	return len(object) > 0
+}
+
+func summarizeAuditPayloadEntries(entries []redis.XMessage, maxEntries int) string {
+	if len(entries) == 0 {
+		return "<empty stream range>"
+	}
+	if maxEntries <= 0 {
+		maxEntries = len(entries)
+	}
+	start := 0
+	if len(entries) > maxEntries {
+		start = len(entries) - maxEntries
+	}
+
+	var builder strings.Builder
+	if start > 0 {
+		_, _ = fmt.Fprintf(&builder, "... %d earlier entries omitted; ", start)
+	}
+	for i, entry := range entries[start:] {
+		if i > 0 {
+			builder.WriteString("; ")
+		}
+		rawJSON, _ := entry.Values["payload_json"].(string)
+		if rawJSON == "" {
+			_, _ = fmt.Fprintf(&builder, "%s <missing payload_json>", entry.ID)
+			continue
+		}
+
+		var payload map[string]interface{}
+		if err := json.Unmarshal([]byte(rawJSON), &payload); err != nil {
+			_, _ = fmt.Fprintf(&builder, "%s <invalid payload_json: %v>", entry.ID, err)
+			continue
+		}
+		_, _ = fmt.Fprintf(
+			&builder,
+			"%s auditID=%s verb=%s ref=%s/%s ns=%s name=%s requestObject=%t responseObject=%t",
+			entry.ID,
+			auditPayloadID(payload),
+			auditPayloadString(payload, "verb"),
+			auditPayloadObjectRefString(payload, "apiGroup"),
+			auditPayloadObjectRefString(payload, "resource"),
+			auditPayloadObjectRefString(payload, "namespace"),
+			auditPayloadObjectRefString(payload, "name"),
+			auditPayloadHasObject(payload, "requestObject"),
+			auditPayloadHasObject(payload, "responseObject"),
+		)
+	}
+	return builder.String()
+}
+
+func auditPayloadString(payload map[string]interface{}, field string) string {
+	value, _ := payload[field].(string)
+	return value
+}
+
+func auditPayloadObjectRefString(payload map[string]interface{}, field string) string {
+	objectRef, _ := payload["objectRef"].(map[string]interface{})
+	if objectRef == nil {
+		return ""
+	}
+	value, _ := objectRef[field].(string)
+	return value
 }
 
 func prettyAuditPayload(payload map[string]interface{}) string {

--- a/test/e2e/audit_redis_e2e_test.go
+++ b/test/e2e/audit_redis_e2e_test.go
@@ -298,6 +298,65 @@ var _ = Describe("Audit Redis Consumer", Label("audit-redis", "smoke"), Ordered,
 		By("cleaning up test ConfigMap")
 		_, _ = kubectlRunInNamespace(testNs, "delete", "configmap", cmName, "--ignore-not-found=true")
 	})
+
+	It("should attribute the commit to the OIDC display name and email from user.extra", func() {
+		const (
+			oidcDisplayName = "Simon Koudijs"
+			oidcEmail       = "something@configbutler.ai"
+		)
+		oidcCMName := fmt.Sprintf("audit-oidc-cm-%d", GinkgoRandomSeed())
+
+		By("creating a ConfigMap while impersonating an OIDC user carrying name/email extras")
+		// Impersonation makes the real kube-apiserver emit an audit event whose
+		// impersonatedUser.Extra carries these keys, mimicking the claims a
+		// structured authentication config maps into user.extra for an OIDC
+		// login. system:masters keeps the impersonated create authorized
+		// without provisioning per-user RBAC.
+		err := createConfigMapAsImpersonatedUser(
+			testNs,
+			oidcCMName,
+			"oidc-simon",
+			[]string{"system:masters"},
+			map[string][]string{
+				"configbutler.ai/claims/display-name": {oidcDisplayName},
+				"configbutler.ai/claims/email":        {oidcEmail},
+			},
+		)
+		Expect(err).NotTo(HaveOccurred(), "failed to create impersonated ConfigMap")
+
+		repoPath := path.Join(
+			"e2e/audit-consumer-test",
+			fmt.Sprintf("v1/configmaps/%s/%s.yaml", testNs, oidcCMName),
+		)
+		expectedFile := filepath.Join(auditRedisRepo.CheckoutDir, repoPath)
+
+		By("waiting for the commit and asserting its author is the OIDC identity")
+		Eventually(func(g Gomega) {
+			pullLatestRepoState(g, auditRedisRepo.CheckoutDir)
+
+			info, statErr := os.Stat(expectedFile)
+			g.Expect(statErr).NotTo(HaveOccurred(),
+				fmt.Sprintf("ConfigMap file should exist at %s", expectedFile))
+			g.Expect(info.Size()).To(BeNumerically(">", 0))
+
+			// Scope the log to this run's unique file path so the author read
+			// back is unambiguously the commit produced by the impersonated
+			// create, regardless of commit-window coalescing.
+			authorCmd := exec.Command(
+				"git", "log", "-1", "--pretty=%an <%ae>", "--", repoPath,
+			)
+			authorCmd.Dir = auditRedisRepo.CheckoutDir
+			authorOut, authorErr := authorCmd.CombinedOutput()
+			g.Expect(authorErr).NotTo(HaveOccurred(),
+				fmt.Sprintf("git log author failed: %s", string(authorOut)))
+			g.Expect(strings.TrimSpace(string(authorOut))).To(
+				Equal(fmt.Sprintf("%s <%s>", oidcDisplayName, oidcEmail)),
+				"commit author should be the OIDC display name and email from user.extra")
+		}, 3*time.Minute, 3*time.Second).Should(Succeed())
+
+		By("cleaning up the test ConfigMap")
+		_, _ = kubectlRunInNamespace(testNs, "delete", "configmap", oidcCMName, "--ignore-not-found=true")
+	})
 })
 
 func valkeyPortForwardAddr() string {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -883,7 +883,7 @@ var _ = Describe("Manager", Label("manager"), Ordered, func() {
 		// observable in at the user-visible layer so a future revamp of the
 		// snapshot trigger logic can't silently regress it.
 		//
-		It("should backfill pre-existing ConfigMap when WatchRule is added afterwards", func() {
+		It("should backfill pre-existing ConfigMap when WatchRule is added afterwards", Label("smoke"), func() {
 			gitProviderName := "gitprovider-normal"
 			watchRuleName := "watchrule-backfill-test"
 			configMapName := "preexisting-configmap"

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -872,6 +872,101 @@ var _ = Describe("Manager", Label("manager"), Ordered, func() {
 				configMapName, uniqueRepoName)
 		})
 
+		// Regression net for the rule-add backfill gap: a ConfigMap that
+		// already exists in the cluster *before* a WatchRule is applied must
+		// land in git once the rule becomes Ready. Today this fails because
+		// ReconcileForRuleChange takes the early-return at manager.go:660
+		// when the new rule's GVR is already covered by other rules (and on
+		// fresh-target installs the snapshot output can be dropped because no
+		// FolderReconciler is registered yet). The unit-level coverage lives
+		// in internal/watch/rule_change_snapshot_test.go; this spec locks the
+		// observable in at the user-visible layer so a future revamp of the
+		// snapshot trigger logic can't silently regress it.
+		//
+		It("should backfill pre-existing ConfigMap when WatchRule is added afterwards", func() {
+			gitProviderName := "gitprovider-normal"
+			watchRuleName := "watchrule-backfill-test"
+			configMapName := "preexisting-configmap"
+			uniqueRepoName := managerRepo.RepoName
+
+			By("creating GitTarget but no WatchRule yet")
+			destName := watchRuleName + "-dest"
+			createGitTarget(destName, testNs, gitProviderName, "e2e/backfill-rule-add", "main")
+			verifyResourceStatus("gittarget", destName, testNs, "True", "Ready", "")
+
+			By("creating the ConfigMap BEFORE the rule that should select it")
+			configMapData := struct {
+				Name      string
+				Namespace string
+			}{
+				Name:      configMapName,
+				Namespace: testNs,
+			}
+			err := applyFromTemplate(
+				"test/e2e/templates/manager/configmap.tmpl",
+				configMapData,
+				testNs,
+				"--as=jane@acme.com",
+			)
+			Expect(err).NotTo(HaveOccurred(), "Failed to pre-create ConfigMap")
+
+			// Confirm nothing committed yet — no rule exists, so the ConfigMap
+			// must not appear in the repo before we apply the WatchRule.
+			expectedRepoPath := path.Join(
+				"e2e/backfill-rule-add",
+				fmt.Sprintf("v1/configmaps/%s/%s.yaml", testNs, configMapName),
+			)
+			expectedFile := filepath.Join(managerRepo.CheckoutDir, expectedRepoPath)
+
+			By("applying the WatchRule (rule arrives after the resource)")
+			watchRuleData := struct {
+				Name            string
+				Namespace       string
+				DestinationName string
+			}{
+				Name:            watchRuleName,
+				Namespace:       testNs,
+				DestinationName: destName,
+			}
+			err = applyFromTemplate("test/e2e/templates/manager/watchrule-configmap.tmpl", watchRuleData, testNs)
+			Expect(err).NotTo(HaveOccurred(), "Failed to apply WatchRule")
+			verifyResourceStatus("watchrule", watchRuleName, testNs, "True", "Ready", "")
+
+			By("waiting for the pre-existing ConfigMap to be backfilled into git")
+			verifyBackfill := func(g Gomega) {
+				pullCmd := exec.Command("git", "pull")
+				pullCmd.Dir = managerRepo.CheckoutDir
+				pullOutput, pullErr := pullCmd.CombinedOutput()
+				if pullErr != nil {
+					g.Expect(pullErr).NotTo(HaveOccurred(),
+						fmt.Sprintf("Should successfully pull latest changes. Output: %s", string(pullOutput)))
+				}
+
+				fileInfo, statErr := os.Stat(expectedFile)
+				g.Expect(statErr).NotTo(HaveOccurred(),
+					fmt.Sprintf("Pre-existing ConfigMap must be backfilled at %s after the rule lands", expectedFile))
+				g.Expect(fileInfo.Size()).To(BeNumerically(">", 0), "Backfilled ConfigMap file should not be empty")
+
+				content, readErr := os.ReadFile(expectedFile)
+				g.Expect(readErr).NotTo(HaveOccurred())
+				g.Expect(string(content)).To(ContainSubstring("test-key: test-value"),
+					"Backfilled file should contain the ConfigMap data that existed before the rule")
+			}
+			Eventually(verifyBackfill).
+				WithTimeout(60 * time.Second).
+				WithPolling(2 * time.Second).
+				Should(Succeed())
+
+			By("cleaning up test resources")
+			_, _ = kubectlRunInNamespace(testNs, "delete", "configmap", configMapName, "--ignore-not-found=true")
+			cleanupWatchRule(watchRuleName, testNs)
+			cleanupGitTarget(destName, testNs)
+
+			By("✅ rule-add backfill E2E test passed")
+			fmt.Printf("✅ Pre-existing ConfigMap '%s' was backfilled to repo '%s' after the WatchRule landed\n",
+				configMapName, uniqueRepoName)
+		})
+
 		It("should delete Git file when ConfigMap is deleted via WatchRule", Label("smoke"), func() {
 			gitProviderName := "gitprovider-normal"
 			watchRuleName := "watchrule-delete-test"

--- a/test/e2e/impersonation_test.go
+++ b/test/e2e/impersonation_test.go
@@ -1,0 +1,83 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright 2025 ConfigButler
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// createConfigMapAsImpersonatedUser creates a ConfigMap while impersonating
+// asUser with the given groups and user.extra entries. The real kube-apiserver
+// then emits an audit event whose impersonatedUser.Extra map carries those
+// entries — the same shape a structured authentication configuration produces
+// when it maps OIDC name/email claims into user.extra. This lets the e2e suite
+// exercise OIDC-style commit authorship without running an identity provider.
+//
+// Authorization for an impersonated request runs as the impersonated identity,
+// so callers pass system:masters as a group to keep the create authorized
+// without provisioning per-user RBAC.
+func createConfigMapAsImpersonatedUser(
+	namespace, name, asUser string,
+	groups []string,
+	extra map[string][]string,
+) error {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	overrides := &clientcmd.ConfigOverrides{}
+	if ctx := kubectlContext(); ctx != "" {
+		overrides.CurrentContext = ctx
+	}
+
+	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		loadingRules, overrides,
+	).ClientConfig()
+	if err != nil {
+		return fmt.Errorf("load kubeconfig: %w", err)
+	}
+
+	config.Impersonate = rest.ImpersonationConfig{
+		UserName: asUser,
+		Groups:   groups,
+		Extra:    extra,
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return fmt.Errorf("build impersonated clientset: %w", err)
+	}
+
+	_, err = clientset.CoreV1().ConfigMaps(namespace).Create(
+		context.Background(),
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			Data:       map[string]string{"test-key": "oidc-author"},
+		},
+		metav1.CreateOptions{},
+	)
+	if err != nil {
+		return fmt.Errorf("create impersonated ConfigMap: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- Add cross-kind `Watches(...)` in `GitTargetReconciler`, `ClusterWatchRuleReconciler`, and `WatchRuleReconciler` so a freshly-applied `GitProvider` / `GitTarget` re-enqueues dependents within tens of milliseconds instead of waiting for the 2-minute periodic requeue.
- New table-driven unit tests in `dependency_watches_test.go` cover each map function (controller package coverage 70.1% → 71.5%).
- Captures the broader bug class and a four-option ladder of structural fixes (library helper, status-driven auto-wiring, auditor check) in `docs/future/idea-cross-kind-dependency-watches.md`.

Fixes #145

## Test plan
- [x] `task fmt`, `task vet`, `task lint`
- [x] `task test` (controller pkg coverage: 70.1% → 71.5%)
- [x] `task test-e2e` (16/43 specs ran, 0 failed)
