### PR TITLE
chore: use mounted git config in place of env variable

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -8,14 +8,7 @@ interactive debugging inside the devcontainer.
 
 ## Quick Start
 
-### VS Code
-
-1. Install the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
-2. Open the project in VS Code: `code .`
-3. Press `F1` and run `Dev Containers: Reopen in Container`
-4. Wait for the initial build to finish
-
-### Before Reopening In Container
+### Prerequisites (Before Reopening In Container)
 
 This repo expects SSH agent forwarding for commit signing.
 
@@ -30,6 +23,14 @@ git config --global user.email "you@example.com"
 ```
 
 If `ssh-add -L` shows no keys, commit signing inside the devcontainer will fail.
+
+
+### VS Code
+
+1. Install the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+2. Open the project in VS Code: `code .`
+3. Press `F1` and run `Dev Containers: Reopen in Container`
+4. Wait for the initial build to finish
 
 ### Verify
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -91,12 +91,12 @@
     "source=codexconfig,target=/home/vscode/.codex,type=volume",
     "source=claudeconfig,target=/home/vscode/.claude,type=volume",
     "source=dotkube,target=/home/vscode/.kube,type=volume",
-    "source=persisted-home,target=/home/vscode/persisted-home,type=volume"
+    "source=persisted-home,target=/home/vscode/persisted-home,type=volume",
+    "source=${localEnv:HOME}${localEnv:USERPROFILE}/.gitconfig,target=/home/vscode/.gitconfig-host,type=bind,consistency=cached"
+
   ],
   "containerEnv": {
     "HOST_PROJECT_PATH": "${localWorkspaceFolder}",
-    "PROJECT_PATH": "/workspaces/${localWorkspaceFolderBasename}",
-    "GIT_USER_NAME": "${localEnv:GIT_USER_NAME}",
-    "GIT_USER_EMAIL": "${localEnv:GIT_USER_EMAIL}"
+    "PROJECT_PATH": "/workspaces/${localWorkspaceFolderBasename}"
   }
 }

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -14,29 +14,29 @@ fail() {
 workspace_dir="${1:-${containerWorkspaceFolder:-${WORKSPACE_FOLDER:-$(pwd)}}}"
 log "Using workspace directory: ${workspace_dir}"
 
-# Resolve Git identity from effective config first, then fallback env vars.
+# Resolve Git identity from effective config first, then fallback to mounted host file.
 git_name="$(git config --get user.name || true)"
 git_email="$(git config --get user.email || true)"
 
-if [ -z "${git_name}" ] && [ -n "${GIT_USER_NAME:-}" ]; then
-  git_name="${GIT_USER_NAME}"
-fi
+if [ -n "$git_name" ] && [ -n "$git_email" ]; then
+  git config --global user.name "$git_name"
+  git config --global user.email "$git_email"
+else
+  HOST_GIT_CONFIG="/home/vscode/.gitconfig-host"
 
-if [ -z "${git_email}" ] && [ -n "${GIT_USER_EMAIL:-}" ]; then
-  git_email="${GIT_USER_EMAIL}"
-fi
+  if [ -f "$HOST_GIT_CONFIG" ]; then
+    git_name=$(git config -f "$HOST_GIT_CONFIG" user.name || true)
+    git_email=$(git config -f "$HOST_GIT_CONFIG" user.email || true)
 
-if [ -z "${git_name}" ] || [ -z "${git_email}" ]; then
-  fail "Missing Git identity. Set user.name and user.email in Git, or provide GIT_USER_NAME and GIT_USER_EMAIL to the devcontainer environment."
-fi
-
-# Persist identity globally in the container if it is not already configured there.
-if ! git config --global --get user.name >/dev/null 2>&1; then
-  git config --global user.name "${git_name}"
-fi
-
-if ! git config --global --get user.email >/dev/null 2>&1; then
-  git config --global user.email "${git_email}"
+    if [ -n "$git_name" ] && [ -n "$git_email" ]; then
+      git config --global user.name "$git_name"
+      git config --global user.email "$git_email"
+    else
+      fail "user.name/user.email not found in host .gitconfig. Set them before rebuilding."
+    fi
+  else
+    fail "Host .gitconfig not mounted. Git identity not configured in container."
+  fi
 fi
 
 log "Refreshing Git SSH signing configuration"


### PR DESCRIPTION
## Description

Using the Dev Containers expects that environment variables `GIT_USER_NAME` and `GIT_USER_EMAIL` are set. These variables are never configured or set directly by GIT. Recommended change is to mount the .gitconfig file and then read the user name and email directly from the file.

## Type of Change

Please delete options that are not relevant.

- [x] Documentation update
- [x] Refactoring (no functional changes)

## Testing

- [x] Unit tests pass locally
- [x] Integration tests pass locally
- [x] Manual testing completed (if applicable)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
