### PR TITLE
fix(e2e): retry k3d image import when the tools-node tarball race drops the image

### DIFF
--- a/hack/e2e/load-image.sh
+++ b/hack/e2e/load-image.sh
@@ -164,12 +164,31 @@ runtime_image_id_in_node() {
 
 import_image() {
 	local ref="$1"
-	echo "Importing ${PROJECT_IMAGE} into k3d cluster ${CLUSTER_NAME}"
-	"${K3D}" image import -c "${CLUSTER_NAME}" "${PROJECT_IMAGE}"
-	local node_name
-	while IFS= read -r node_name; do
-		pin_imported_image "${node_name}" "${ref}" "${PROJECT_IMAGE}" "${IMAGE_REPO}" "${IMAGE_TAG}"
-	done < <(cluster_node_names)
+	local attempt node_name pinned
+	# k3d's tools-node import path can transiently lose the tarball between the
+	# save and the per-node `ctr image import` ("ctr: open /k3d/images/<tar>:
+	# no such file or directory") — and k3d still exits 0, logging "Successfully
+	# imported". The pin step below is what actually detects the miss, so on a
+	# failed pin re-run the whole import instead of giving up.
+	for attempt in 1 2 3; do
+		echo "Importing ${PROJECT_IMAGE} into k3d cluster ${CLUSTER_NAME} (attempt ${attempt}/3)"
+		"${K3D}" image import -c "${CLUSTER_NAME}" "${PROJECT_IMAGE}"
+		pinned=1
+		while IFS= read -r node_name; do
+			if ! pin_imported_image "${node_name}" "${ref}" "${PROJECT_IMAGE}" "${IMAGE_REPO}" "${IMAGE_TAG}"; then
+				pinned=0
+				break
+			fi
+		done < <(cluster_node_names)
+		if [[ "${pinned}" == "1" ]]; then
+			return 0
+		fi
+		if [[ "${attempt}" -lt 3 ]]; then
+			echo "WARN: ${PROJECT_IMAGE} missing from cluster nodes after import attempt ${attempt}; retrying" >&2
+		fi
+	done
+	echo "ERROR: k3d image import failed to deliver ${PROJECT_IMAGE} after 3 attempts" >&2
+	return 1
 }
 
 if [[ "${IMAGE_DELIVERY_MODE}" == "pull" ]]; then


### PR DESCRIPTION
## Why

The first external-contributor PR through the new artifact-based CI path (#178, run [28610319679](https://github.com/ConfigButler/gitops-reverser/actions/runs/28610319679)) failed in E2E (quickstart). The artifact delivery itself worked — the project image was docker-loaded on the runner and k3d's tools node saved it from the runtime — but k3d then hit a transient race in its tools-node import flow:

```
ERRO failed to import images in node 'k3d-...-server-0': ...
ctr: open /k3d/images/k3d-...-images-20260702175725.tar: no such file or directory
INFO Successfully imported 1 image(s) into 1 cluster(s)   <-- k3d still exits 0
```

The pin/verify step in `hack/e2e/load-image.sh` correctly caught that the image never landed in containerd and failed the prepare. Since the CI rework, every PR e2e job delivers the image via `k3d image import` (load mode) instead of a registry pull, so this pre-existing k3d flake now has much more exposure.

Same pipeline passed 3 imports on PR #180's own run and on the release-please 0.29.1 run, same runner image, 79 GB disk free at failure time — confirming it's an intermittent k3d race, not a problem with the artifact wiring.

## What

`import_image()` now retries the import + pin/verify sequence up to 3 times; the pin step is the only reliable signal that the import actually succeeded, because k3d exits 0 even when a node's `ctr image import` fails.

## Validation

- `task fmt` / `task generate` / `task manifests` / `task vet`: clean
- `task lint`: 0 issues
- `task test`: pass (coverage 73.8%, baseline 73.9%, within tolerance)
- `task test-e2e`: pass (53/53 specs, 8 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)