### PR TITLE
fix(e2e): deliver image via k3d direct mode (root cause of the tools-node race)

### DIFF
--- a/hack/e2e/load-image.sh
+++ b/hack/e2e/load-image.sh
@@ -165,21 +165,33 @@ runtime_image_id_in_node() {
 import_image() {
 	local ref="$1"
 	local attempt node_name pinned
-	# k3d's tools-node import path can transiently lose the tarball between the
-	# save and the per-node `ctr image import` ("ctr: open /k3d/images/<tar>:
-	# no such file or directory") — and k3d still exits 0, logging "Successfully
-	# imported". The pin step below is what actually detects the miss, so on a
-	# failed pin re-run the whole import instead of giving up.
+	# Deliver with `-m direct` (docker save streamed straight into each node's
+	# `ctr image import` stdin) rather than the default tools-node mode. The
+	# tools-node path has a race: k3d's exec poll can misread the save-image
+	# exec as finished before the tarball hits the shared volume, the node
+	# import then fails ("ctr: open /k3d/images/<tar>: no such file or
+	# directory") — and k3d logs the error but still exits 0. Direct mode has
+	# no tarball/volume window and DOES propagate node import failures.
+	# Caveat: direct + ctr's --all-platforms chokes on multi-arch images saved
+	# by a containerd-store docker (foreign-platform blobs absent from the
+	# stream); PROJECT_IMAGE is always the single-arch controller image.
+	#
+	# Trust nothing either way: the pin step below verifies the image really
+	# landed in every node, and any failed attempt (loud or silent) is retried.
 	for attempt in 1 2 3; do
 		echo "Importing ${PROJECT_IMAGE} into k3d cluster ${CLUSTER_NAME} (attempt ${attempt}/3)"
-		"${K3D}" image import -c "${CLUSTER_NAME}" "${PROJECT_IMAGE}"
 		pinned=1
-		while IFS= read -r node_name; do
-			if ! pin_imported_image "${node_name}" "${ref}" "${PROJECT_IMAGE}" "${IMAGE_REPO}" "${IMAGE_TAG}"; then
-				pinned=0
-				break
-			fi
-		done < <(cluster_node_names)
+		if "${K3D}" image import -m direct -c "${CLUSTER_NAME}" "${PROJECT_IMAGE}"; then
+			while IFS= read -r node_name; do
+				if ! pin_imported_image "${node_name}" "${ref}" "${PROJECT_IMAGE}" "${IMAGE_REPO}" "${IMAGE_TAG}"; then
+					pinned=0
+					break
+				fi
+			done < <(cluster_node_names)
+		else
+			echo "WARN: k3d image import exited nonzero on attempt ${attempt}" >&2
+			pinned=0
+		fi
 		if [[ "${pinned}" == "1" ]]; then
 			return 0
 		fi


### PR DESCRIPTION
Follow-up to #185, with the root cause now pinned down in the k3d v5.9.0 source.

## Why the import was failing (the actual mechanism)

Two k3d defects combine in the default tools-node mode:

1. **Exec-status race** (`pkg/runtimes/docker/node.go`, `executeInNode`): k3d polls `ContainerExecInspect` every 1s and treats `Running=false, ExitCode=0` as success. Docker's exec lifecycle is asynchronous, so a poll can misread the `save-image` exec as complete **before the tarball exists** on the shared image volume. In the failing run ([28610319679](https://github.com/ConfigButler/gitops-reverser/actions/runs/28610319679)) the "save" appeared to finish within the same second (passing runs take ~2s), then `server-0`'s `ctr image import` hit `no such file or directory`.
2. **Swallowed node errors** (`pkg/client/tools.go`, `importWithToolsNode`): the per-node import failure is only `Errorf`-logged, never returned — k3d prints "Successfully imported" and exits 0. Only our pin/verify step told the truth.

## What this changes

`k3d image import -m direct`: streams `docker save` straight into each node's `ctr image import` stdin (`loadImageFromStream`) — **no tarball, no shared-volume timing window**, and node import failures **are propagated** through an errgroup. The retry from #185 now also covers a loud nonzero k3d exit, and the pin step remains the final proof the image landed.

## Verified on a live 4-node cluster

- `-m direct` with the real project image: 5.4s, image present + pinned in all 4 nodes.
- Full `task test-e2e` with the stamp cleared (forcing the new path, including the image-refresh rebuild→reload cycles): 53/53 specs passed, 8 skipped, 9m15s.
- Gotcha discovered and documented in-script: direct mode + k3d's hardcoded `ctr --all-platforms` fails (`content digest not found`) for **multi-arch** images saved by a containerd-store docker — the stream lacks foreign-platform blobs (file-based import of the same tar fails identically, so it's the save format, not stdin). `PROJECT_IMAGE` is always the single-arch controller image, so this doesn't apply to us.

## Validation

- `task lint`: 0 issues
- `task test`: pass (coverage 73.8%, within tolerance of 73.9% baseline)
- `task test-e2e`: pass (53/53)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image loading reliability during end-to-end setup, reducing transient failures when importing test images.
  * Added clearer retry handling so failed import attempts are detected and retried more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->