### PR TITLE
perf(build): cache Go build + module dirs in Dockerfile builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,9 @@ WORKDIR /workspaces
 # Copy the Go Modules manifests
 COPY go.mod go.sum ./
 # cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN go mod download
+# and so that source changes don't invalidate our downloaded layer. The module
+# cache is a BuildKit cache mount so it also survives across builds.
+RUN --mount=type=cache,target=/go/pkg/mod go mod download
 
 # Copy the go source
 COPY cmd/ cmd/
@@ -32,7 +33,18 @@ COPY internal/ internal/
 
 # Build for the target platform. ${GOCOVER:+...} expands to the coverage flags
 # only when GOCOVER is non-empty, instrumenting every package in the module.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
+#
+# The Go build and module caches are BuildKit cache mounts, so they persist
+# across builds instead of starting empty every time. A source change still
+# recompiles (only the changed packages + dependents), but a rebuild no longer
+# recompiles the whole module + all deps from scratch — the dominant cost of the
+# e2e image-refresh chain, which rebuilds the controller several times per run
+# (see docs/design/e2e-ci-runner-sharding-plan.md). Also speeds up local
+# `task test-e2e` rebuilds. The cache is content-addressed and keyed by
+# GOOS/GOARCH/flags, so cross-arch and coverage builds stay isolated.
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
     ${GOCOVER:+-cover -covermode=atomic -coverpkg=github.com/ConfigButler/gitops-reverser/...} \
     -ldflags "-X main.version=${VERSION} -X main.gitCommit=${GIT_COMMIT} -X main.gitDirty=${GIT_DIRTY} -X main.buildDate=${BUILD_DATE}" \
     -o manager ./cmd


### PR DESCRIPTION
## What

Add BuildKit cache mounts for the Go build cache (`/root/.cache/go-build`) and module cache (`/go/pkg/mod`) to the `Dockerfile` builder stage.

## Why

The builder stage had **no cache mount**, so every `docker build` started with an empty Go build cache and recompiled the **entire module** (client-go, controller-runtime, all deps) from scratch (~100 s) — even for a one-line source change.

That is the dominant cost of the **e2e `image-refresh` leg**, which deliberately changes a source file and rebuilds the controller **~5 times per run** to prove a change triggers a rebuild + rollout. On the newly-sharded CI matrix that leg is the critical path at **~15 min** (run `28681013051`), almost all of it cold recompiles. This surfaced while analysing the e2e sharding (see [`docs/design/e2e-ci-runner-sharding-plan.md`](../blob/main/docs/design/e2e-ci-runner-sharding-plan.md)).

## Effect

A source change still recompiles (only the changed packages + dependents), so the image-refresh assertions still hold — but a rebuild no longer recompiles the world.

**Verified locally:** after appending a comment to `cmd/main.go` (exactly what image-refresh `S2` does), the `go build` step dropped from a cold full compile to **~2 s incremental** (5 s total build). Expected to cut the `image-refresh` leg roughly in half and also speed up local `task test-e2e` rebuilds and the CI `build` job on warm cache.

## Safety

- The cache is content-addressed and keyed by `GOOS`/`GOARCH`/flags, so cross-arch and coverage (`GOCOVER`) builds stay isolated.
- Requires BuildKit — the default on modern Docker.
- Final binary is byte-for-byte the same; only build caching changes.

## Validation

- `task lint` (incl. `hadolint`) — green
- Local `docker build` twice with a source change between — builds succeed, rebuild is ~2 s
- Full `task test-e2e` deferred to CI (this PR's e2e run exercises the image-refresh chain directly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build performance by reusing cached dependencies during container builds.
  * Reduced rebuild times for development and CI workflows while preserving existing build behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->