### PR TITLE
chore(release): pin release-please baseline to the v0.29.2 commit

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
     ".": {
       "release-type": "simple",
       "package-name": "gitops-reverser",
+      "last-release-sha": "7a53779c6a8da0dbff72940011c34396a85530cc",
       "bump-minor-pre-major": true,
       "draft": true,
       "changelog-sections": [


### PR DESCRIPTION
## Problem

release-please PR **#196** proposes a bogus **0.30.0** that re-lists **168 already-shipped commits** and re-declares breaking changes that released back in **v0.28.0**. It is fresh (created right after 0.29.2, Release Please job succeeded), so this is live misbehaviour, not a stale PR.

**Root cause:** the failed **0.29.1** release was manually deleted. Its GitHub release is gone (tag still present, no release), which broke release-please's last-release tracking — it walked back to ~v0.27.1 as its baseline.

Meanwhile `main` sits **exactly on the v0.29.2 tag with 0 commits after it**, and v0.29.2 itself is a fully-signed, verified release (image + chart signatures, SLSA provenance, SPDX SBOM all check out). So there is genuinely nothing to release right now.

## Fix

Pin `last-release-sha` to the v0.29.2 release commit (`7a53779c6a8da0dbff72940011c34396a85530cc`) so release-please only considers commits **after** 0.29.2.

- On the next release-please run (this PR merging to `main`), it will find no releasable commits and **close/empty #196**.
- Future releases bump correctly from 0.29.2 (`feat` → 0.30.0, `fix`/`perf` → 0.29.3) with only real new commits in the changelog.
- Typed `chore(release):` — **non-bumping**, so it does not itself trigger a release.
- Reversible: the pin can be removed after the next clean release once the tag chain is trusted again.

## Do not merge #196
Merging it would tag `0.30.0` on a commit identical to 0.29.2 and re-announce already-shipped breaking changes. Merge **this** PR instead, confirm #196 auto-closes.

## Follow-up (separate, destructive — not in this PR)
The failed 0.29.1 also left orphans to clean up: the stray `gitops-reverser-v0.29.1` git tag, and unsigned partial `:0.29.1` artifacts in GHCR (image + chart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release tracking metadata to point to the latest commit anchor for future release generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->