### PR TITLE
fix(sanitize): strip the kcp.io/cluster annotation from Git writes

### DIFF
--- a/internal/sanitize/types.go
+++ b/internal/sanitize/types.go
@@ -95,11 +95,17 @@ func isOperationalLabel(key string) bool {
 // that belongs in Git, and stripping them would silently drop a user's sync
 // ordering. Hence the exact-key match.
 //
+// `kcp.io/cluster` is matched exactly for the same reason. kcp stamps it on every
+// object to name the logical cluster the object was read from, so it is an address
+// rather than intent: committed to Git it would pin a manifest to one workspace and
+// travel with it into every other. Sibling `kcp.io/` keys are not assumed to be
+// bookkeeping too, so this is not a prefix strip either.
+//
 // Exercised end-to-end against a real Argo CD in
 // test/e2e/argocd_bi_directional_e2e_test.go.
 func isOperationalAnnotation(key string) bool {
 	switch key {
-	case "argocd.argoproj.io/tracking-id", "argocd.argoproj.io/installation-id":
+	case "argocd.argoproj.io/tracking-id", "argocd.argoproj.io/installation-id", "kcp.io/cluster":
 		return true
 	}
 

--- a/internal/sanitize/types_test.go
+++ b/internal/sanitize/types_test.go
@@ -310,11 +310,36 @@ func TestCleanAnnotations(t *testing.T) {
 			},
 		},
 		{
+			// kcp names the logical cluster an object was read from. It is an address,
+			// not intent: in Git it would pin the manifest to one workspace and travel
+			// with it into every other.
+			name: "remove kcp logical-cluster annotation",
+			input: map[string]string{
+				"kcp.io/cluster":  "root:org:team",
+				"user-annotation": "kept",
+			},
+			expected: map[string]string{
+				"user-annotation": "kept",
+			},
+		},
+		{
+			// Exact-key, not a `kcp.io/` prefix strip: sibling keys under the prefix are
+			// not assumed to be bookkeeping.
+			name: "keep other kcp annotations",
+			input: map[string]string{
+				"kcp.io/path": "kept",
+			},
+			expected: map[string]string{
+				"kcp.io/path": "kept",
+			},
+		},
+		{
 			name: "all annotations operational - return nil",
 			input: map[string]string{
 				"kubectl.kubernetes.io/last-applied-configuration": "removed",
 				"control-plane.alpha.kubernetes.io/leader":         "removed",
 				"argocd.argoproj.io/tracking-id":                   "removed",
+				"kcp.io/cluster":                                   "removed",
 			},
 			expected: nil,
 		},


### PR DESCRIPTION
## Why

kcp stamps `kcp.io/cluster` on every object it serves, naming the logical cluster the object was read from. That makes it an **address, not intent**: it describes where a copy of the object happened to live, not anything the user asked for.

Committed to Git it is actively wrong, and in the way that is hardest to notice — the manifest is pinned to one workspace, and then travels with that pin into every other workspace it is applied to.

## What

One key added to the operational-annotation set in [`internal/sanitize/types.go`](https://github.com/ConfigButler/gitops-reverser/blob/fix/sanitize-kcp-cluster-annotation/internal/sanitize/types.go):

```go
switch key {
case "argocd.argoproj.io/tracking-id", "argocd.argoproj.io/installation-id", "kcp.io/cluster":
    return true
}
```

## Why it is an exact key and not a `kcp.io/` prefix strip

Deliberately, and for the same reason the Argo CD keys next to it are exact.

A prefix strip is the tempting shape and the wrong one: it assumes every sibling key under the vendor prefix is bookkeeping too. That assumption is what the existing comment on `isOperationalAnnotation` already warns about for `argocd.argoproj.io/` — a blanket strip there would silently drop `sync-wave`, `sync-options`, `hook` and other genuine user intent. Nothing tells us `kcp.io/` is safer, so it gets the same treatment.

Two tests pin the asymmetry rather than leaving it to the comment:

- `remove kcp logical-cluster annotation` — `kcp.io/cluster` is stripped
- `keep other kcp annotations` — `kcp.io/path` survives

If a second kcp key ever turns out to be bookkeeping, it should be added by name, and its own test should say so.

## Scope

Annotations only — kcp carries this as an annotation, so `isOperationalLabel` is untouched. No behavior change for any object that does not carry the key.

`docs/bi-directional.md`'s stripped-metadata table is a Flux-vs-Argo comparison, so kcp has no row there; the rationale lives in the godoc on `isOperationalAnnotation`, where the sibling reasoning already is.

## Validation

`task fmt` ✅ · `task vet` ✅ · `task lint` ✅ (0 issues) · `task test` ✅ (coverage 75.4%, within the 0.5% tolerance of the 75.5% baseline — no baseline change) · `task test-e2e` ✅ (54 passed, 0 failed, 10 skipped — the skips are the opt-in bi-directional corner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
