### PR TITLE
ci(release): tag releases plainly (vX.Y.Z), dropping the component prefix

### DIFF
--- a/pkg/manifestanalyzer/doc.go
+++ b/pkg/manifestanalyzer/doc.go
@@ -16,7 +16,11 @@
 // GitOps Reverser is pre-1.0, and so is this package. It is the surface a tool is meant
 // to build on rather than reaching into internal/, but it carries no compatibility
 // guarantee: fields may be renamed, removed, or given a new meaning in any release, and
-// [SchemaVersion] may bump for reasons that would be breaking after 1.0. Pin a version.
+// [SchemaVersion] may bump for reasons that would be breaking after 1.0. Pin a version: each
+// release is tagged `vX.Y.Z`, so `go get github.com/ConfigButler/gitops-reverser@vX.Y.Z` (and
+// `go install github.com/ConfigButler/gitops-reverser/cmd/manifest-analyzer@vX.Y.Z`) resolve to
+// that release rather than an opaque pseudo-version — the whole repository is one Go module,
+// versioned as a unit.
 //
 // Two habits will nonetheless save you work. Ignore fields you do not recognise, because
 // new ones do get added. Do not switch on the human-readable strings — [Issue.Message]

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,8 @@
     ".": {
       "release-type": "simple",
       "package-name": "gitops-reverser",
-      "last-release-sha": "7a53779c6a8da0dbff72940011c34396a85530cc",
+      "include-component-in-tag": false,
+      "last-release-sha": "64bebc0dc6adc45ed29c6cb281ffa9ce0d68aba7",
       "bump-minor-pre-major": true,
       "draft": true,
       "changelog-sections": [


### PR DESCRIPTION
## The problem (finding #13)

`pkg/manifestanalyzer`'s doc says *"Pin a version."* No consumer could: the module is at the repository root (`module github.com/ConfigButler/gitops-reverser`), but release-please tagged releases **`gitops-reverser-vX.Y.Z`**. Go resolves a **root** module by plain `vX.Y.Z` tags only, so both consumers of this repo failed to resolve by version:

```console
$ go get github.com/ConfigButler/gitops-reverser@v0.36.0                       # library
$ go install github.com/ConfigButler/gitops-reverser/cmd/manifest-analyzer@v0.36.0  # CLI
go: invalid version: unknown revision v0.36.0
```

## Why drop the prefix instead of adding a second tag

An earlier version of this PR *mirrored* each release to a plain tag. On review, the prefix turned out to buy nothing:

- **Nothing depends on it.** No code, docs, scripts, or workflow references `gitops-reverser-v*`. Every release-workflow reference uses release-please's `tag_name` **output**; image tags come from the `version` output. So emitting `v0.36.0` instead just works everywhere.
- **It's one Go module.** The operator image, the `manifest-analyzer` CLI, and the `pkg/manifestanalyzer` library are three *artifacts*, but one `go.mod` — one version. The `gitops-reverser-` prefix is release-please's component format (hyphen), not Go's submodule convention (`subdir/vX.Y.Z`, slash), so it maps to no module boundary and can never make the artifacts independently versionable.
- **The "components" argument favours plain tags.** The library (`go get`) and CLI (`go install`) are exactly the consumers that need plain `vX.Y.Z` on the root module to resolve. A single tag versions all three artifacts together — which is the point (the `internal/cluster` guard exists to keep the image and the linked library at the *same* release).

The prefix would only earn its keep if a package were split into its **own** `go.mod` — a real refactor (a separate module can't import `internal/`), and even then its tag would be `pkg/manifestanalyzer/vX.Y.Z` (slash), not today's format.

## The change

- `release-please-config.json`: `"include-component-in-tag": false` → releases tag `vX.Y.Z` directly.
- `last-release-sha` bumped to the `0.36.0` release commit so the next changelog anchors correctly without matching the old prefixed tags.
- `pkg/manifestanalyzer/doc.go`: the "Pin a version" note now says `@vX.Y.Z` (and `go install …@vX.Y.Z`) resolve.
- No mirror job — simpler than the earlier version of this PR.

## Notes

- Existing `gitops-reverser-vX.Y.Z` tags stay as history; the **next** release cuts the first `vX.Y.Z`. To make `@v0.36.0` resolve immediately, a maintainer can backfill once: `git tag v0.36.0 gitops-reverser-v0.36.0 && git push origin v0.36.0`.
- Only real risk is release-please's own switch; the config anchors it via the manifest (`0.36.0`) + `last-release-sha`, and it's validated on the next release to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how tagged releases and module versioning affect version selection when using `go get` and `go install`.

* **Chores**
  * Updated release configuration to use consistent version tags and release tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->