### PR TITLE
fix(release): give the analyzer job the bash it was written for

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -412,6 +412,13 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
+    # A container job defaults to `sh`, not the `bash` a runner-hosted job gets, and dash
+    # rejects `set -o pipefail` outright: the build step below died on its own first line
+    # with "Illegal option -o pipefail", before compiling anything. Declaring the shell for
+    # the whole job keeps a later step from silently inheriting dash again.
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
The 0.40.0 release failed. `Publish manifest-analyzer` died in 59 seconds having compiled nothing:

```
shell: sh -e {0}
/__w/_temp/….sh: 1: set: Illegal option -o pipefail
##[error]Process completed with exit code 2
```

`publish-analyzer` declares `container:`, and GitHub defaults a container job's shell to `sh` (dash), not the `bash` a runner-hosted job gets. The build step opens with `set -euo pipefail`, which dash rejects outright, so it exited on its own first line.

This is deterministic, not flaky. The job is gated on `release_created == 'true'`, so it had never executed before: it was cancelled in the run that introduced it and skipped in the run after. Its first execution was the 0.40.0 release, and it will fail identically on every release until this lands.

The build itself is sound — compiling all three platforms and running the `--version` assertion under bash succeeds. The shell was the only defect.

## The fix

`defaults: run: shell: bash` on the job, rather than `shell: bash` on the one broken step, so a step added later cannot silently inherit dash again.

`publish-helm` is the other `container:` job and has the identical latent trap, but it uses no bash-only syntax today. Left untouched to keep this hotfix narrow.

## What the failure cost

| Artifact | State |
|---|---|
| Image `ghcr.io/configbutler/gitops-reverser:0.40.0` | Published |
| Chart `oci://ghcr.io/configbutler/charts/gitops-reverser` 0.40.0 | Published |
| GitHub Release v0.40.0 | Stranded draft — carries install/crds/sbom assets, no analyzer binaries |
| Tag `v0.40.0` | Does not exist (a draft release creates no tag) |

The image and chart shipped; `publish-release` never ran, so the release stayed a draft.

Note for recovery: re-running the failed job does **not** help — a re-run uses the workflow file from the triggering commit, which still has the bug. This fix has to ride out on a subsequent release, and the stranded v0.40.0 draft should be deleted.

## Validation

`task lint` (incl. actionlint), `task test` (77.9%, baseline 78.0%), `task test-e2e` (69 of 91 specs, 0 failed) all pass. Reproduced the cause directly: `sh -e -c 'set -euo pipefail'` exits 2 with `Illegal option -o pipefail`; the same line under `bash -e -c` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release build reliability by standardizing command execution in the publishing workflow.
  * Prevented shell compatibility issues from interrupting build steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->