### PR TITLE
fix(e2e): fail fast on a wedged cluster; devcontainer Git identity + SSH signing bootstrap

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -24,6 +24,11 @@ git config --global user.email "you@example.com"
 
 If `ssh-add -L` shows no keys, commit signing inside the devcontainer will fail.
 
+If the environment creating the devcontainer has no Git config to hand over, set `GIT_USER_NAME` and
+`GIT_USER_EMAIL` in that environment instead; [`devcontainer.json`](./devcontainer.json) forwards
+both through `${localEnv:...}` and `post-create.sh` writes them into the container's global Git
+config. Configured Git config always wins over these variables.
+
 ### VS Code
 
 1. Install the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
@@ -43,31 +48,66 @@ bash -ic 'complete -p task >/dev/null && echo task completion ok'
 docker version
 gh --version
 git config --get gpg.format
-git config --get user.signingkey
 ssh-add -L
 ```
 
 Expected Git signing values:
 
 ```bash
-git config --get gpg.format         # ssh
-git config --get commit.gpgsign    # true
-git config --get user.signingkey   # /home/vscode/.ssh/devcontainer_signing_key.pub
+git config --get gpg.format                # ssh
+git config --get commit.gpgsign            # true
+git config --get gpg.ssh.defaultKeyCommand # ssh-add -L
+git config --get gpg.ssh.allowedSignersFile # /home/vscode/.config/git/allowed_signers
 ```
+
+`user.signingkey` is set only when an agent key comment matches your Git email; otherwise it stays
+unset and the key is read from the agent at commit time.
 
 ## How SSH Signing Works Here
 
 The devcontainer uses SSH commit signing, not GPG keyring-based signing.
 
-- [`post-create.sh`](./post-create.sh) bootstraps Git identity and calls the signing sync helper
-- [`sync-signing-key.sh`](./sync-signing-key.sh) reads the forwarded SSH agent and refreshes:
-  - `${HOME}/.ssh/devcontainer_signing_key.pub`
-  - `${HOME}/.config/git/allowed_signers`
-- [`devcontainer.json`](./devcontainer.json) runs the helper on:
-  - `postCreateCommand`
-  - `postStartCommand`
+Most of it is plain Git configuration rather than shell logic:
 
-This keeps the configured public key file aligned with the currently forwarded agent key.
+```bash
+commit.gpgsign=true                    # every commit is signed
+gpg.format=ssh                         # signed with an SSH key
+gpg.ssh.defaultKeyCommand="ssh-add -L" # the key comes from the live agent
+```
+
+With those three set, Git signs with whatever the agent currently holds, and refuses to commit
+when it holds nothing. No key is cached anywhere, so there is nothing to go stale when a
+reconnect changes the forwarded socket or the loaded key.
+
+[`sync-signing-key.sh`](./sync-signing-key.sh) applies that baseline and adds the one thing Git
+cannot derive on its own: `${HOME}/.config/git/allowed_signers`, which maps the Git email to the
+keys currently in the agent so `git log --show-signature` can verify. It runs from
+[`post-start.sh`](./post-start.sh) on every start, and can be run by hand at any time.
+
+If one of the agent keys has a comment containing your Git email, that key is pinned as
+`user.signingkey` so selection does not depend on agent order. With no such key the pin is left
+unset, which is both simpler and immune to going stale. A signing key you configured yourself is
+never overwritten.
+
+[`post-create.sh`](./post-create.sh) does not configure signing. Creating the environment,
+personalizing Git, and having credentials available are three separate things, and only the first
+has to succeed for the container to be usable.
+
+### When No Agent Has Attached Yet
+
+A devcontainer can be created before any interactive session attaches, for example by
+`devcontainer up` from the Dev Containers CLI, or by a platform that personalizes the workspace
+afterwards. No SSH agent is forwarded at that point, and no Git identity may exist yet. Neither is
+treated as a failure to create the environment: the hooks report what is missing and finish.
+
+Signing is not relaxed to achieve that. `commit.gpgsign` is on from the start, so a commit without
+a usable key fails:
+
+```text
+fatal: either user.signingkey or gpg.ssh.defaultKeyCommand needs to be configured
+```
+
+Nothing else in the environment needs a key, so builds, tests and the E2E suite run regardless.
 
 ## Best Practices
 
@@ -96,18 +136,24 @@ workflows.
 3. Keep signing setup in one small script
    This repo uses [`sync-signing-key.sh`](./sync-signing-key.sh) for that reason.
 
-4. Prefer deterministic key selection
-   The helper first looks for an SSH key whose comment matches `git user.email`.
-   If none matches, it falls back to the first key from `ssh-add -L`.
+4. Prefer standard Git mechanisms over shell logic
+   `gpg.ssh.defaultKeyCommand` selects the key whenever no comment matches the Git email, so there
+   is usually no pinned key to become stale.
 
-5. Keep signing and verification data in sync
-   `user.signingkey` and `gpg.ssh.allowedSignersFile` are regenerated together.
+5. Trust every key the agent currently holds
+   `allowed_signers` lists them all under the Git email, so verification works whichever one the
+   key command picks.
 
 6. Store only public key material in the container
    The private key stays on the host and is accessed through the forwarded SSH agent.
 
-7. Fail early with actionable messages
-   Missing agent, missing keys, or missing Git identity should stop setup immediately.
+7. Report, do not fail
+   A missing identity or agent is diagnosed and setup continues. Git, not a shell script, is what
+   refuses an unsigned commit.
+
+8. Use the Git email as the `allowed_signers` principal
+   That file takes bare identities, so a `Name <email>` principal makes `ssh-keygen -Y verify`
+   report `invalid key` and `No principal matched` for a correctly signed commit.
 
 ### General Devcontainer Maintenance
 
@@ -123,9 +169,8 @@ workflows.
 ```bash
 echo "$SSH_AUTH_SOCK"
 ssh-add -L
-cat ~/.ssh/devcontainer_signing_key.pub
 cat ~/.config/git/allowed_signers
-git config --show-origin --get user.signingkey
+git config --show-origin --get-regexp '^(commit\.gpgsign|gpg\.)'
 ```
 
 ## Optional `.env` for `gh`
@@ -159,8 +204,8 @@ Check:
 
 ```bash
 ssh-add -L
-cat ~/.ssh/devcontainer_signing_key.pub
-git config --get user.signingkey
+git config --get commit.gpgsign
+git config --get gpg.ssh.defaultKeyCommand
 ```
 
 Then refresh the signing setup manually:
@@ -173,14 +218,25 @@ Common causes:
 
 - no host `ssh-agent` running
 - no key loaded into the host agent
-- the forwarded agent key changed after the container was created
 - `user.name` or `user.email` is missing
 
-Typical signing error when the configured public key is stale:
+Typical error when no key is reachable:
 
 ```text
-error: No private key found for public key "/home/vscode/.ssh/devcontainer_signing_key.pub"?
+fatal: either user.signingkey or gpg.ssh.defaultKeyCommand needs to be configured
 ```
+
+### Commits Sign But Do Not Verify
+
+```text
+allowed_signers:1: invalid key
+No principal matched.
+```
+
+The principal in `~/.config/git/allowed_signers` is malformed. Each line is
+`<email> <keytype> <key> [comment]`; re-run `bash .devcontainer/sync-signing-key.sh` to regenerate
+it. Verify with `git log -1 --show-signature`, and check the helper itself with
+`bash .devcontainer/test-signing.sh`.
 
 ### Push Fails But Commit Signing Works
 
@@ -213,7 +269,9 @@ Usually normal. Rebuild time mostly depends on tool installation and cache reuse
 - [`Dockerfile`](./Dockerfile) - Multi-stage container image
 - [`devcontainer.json`](./devcontainer.json) - VS Code devcontainer configuration
 - [`post-create.sh`](./post-create.sh) - Initial bootstrap
+- [`post-start.sh`](./post-start.sh) - Per-start refresh
 - [`sync-signing-key.sh`](./sync-signing-key.sh) - SSH signing refresh helper
+- [`test-signing.sh`](./test-signing.sh) - Tests for the signing helper, using a disposable key
 - [`README.md`](./README.md) - This document
 
 ## References

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -196,6 +196,10 @@ Recommended token scopes:
 
 The repo-root `.env` must stay local. It is already gitignored.
 
+Alternatively just run `gh auth login` once. `~/.config/gh` is a named volume (`ghconfig`), so the
+login survives container rebuilds; the first rebuild after this mount was added starts from an
+empty volume and needs one more login.
+
 ## Troubleshooting
 
 ### Commit Signing Fails

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -97,6 +97,9 @@
     "source=codexconfig,target=/home/vscode/.codex,type=volume",
     "source=claudeconfig,target=/home/vscode/.claude,type=volume",
     "source=dotkube,target=/home/vscode/.kube,type=volume",
+    // Keeps the gh CLI logged in across rebuilds. Without it every rebuild drops
+    // ~/.config/gh and gh asks for `gh auth login` again.
+    "source=ghconfig,target=/home/vscode/.config/gh,type=volume",
     "source=persisted-home,target=/home/vscode/persisted-home,type=volume"
   ],
   "containerEnv": {

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -6,15 +6,13 @@ log() {
   echo "[post-create] $*"
 }
 
-fail() {
-  echo "[post-create] ERROR: $*" >&2
-  exit 1
-}
-
 workspace_dir="${1:-${containerWorkspaceFolder:-${WORKSPACE_FOLDER:-$(pwd)}}}"
 log "Using workspace directory: ${workspace_dir}"
 
-# Resolve Git identity from effective config first, then fallback env vars.
+# Git identity is developer personalization, not part of building a usable
+# development environment, so its absence is reported and not fatal. Whatever
+# created this container (VS Code copying the host Git config, a platform's own
+# personalization step) may supply it before, during or after this hook.
 git_name="$(git config --get user.name || true)"
 git_email="$(git config --get user.email || true)"
 
@@ -26,21 +24,23 @@ if [ -z "${git_email}" ] && [ -n "${GIT_USER_EMAIL:-}" ]; then
   git_email="${GIT_USER_EMAIL}"
 fi
 
-if [ -z "${git_name}" ] || [ -z "${git_email}" ]; then
-  fail "Missing Git identity. Set user.name and user.email in Git, or provide GIT_USER_NAME and GIT_USER_EMAIL to the devcontainer environment."
-fi
-
-# Persist identity globally in the container if it is not already configured there.
-if ! git config --global --get user.name >/dev/null 2>&1; then
+if [ -n "${git_name}" ] && [ -z "$(git config --global --get user.name || true)" ]; then
   git config --global user.name "${git_name}"
 fi
 
-if ! git config --global --get user.email >/dev/null 2>&1; then
+if [ -n "${git_email}" ] && [ -z "$(git config --global --get user.email || true)" ]; then
   git config --global user.email "${git_email}"
 fi
 
-log "Refreshing Git SSH signing configuration"
-bash "${workspace_dir}/.devcontainer/sync-signing-key.sh"
+if [ -z "${git_name}" ] || [ -z "${git_email}" ]; then
+  log "WARNING: no Git identity yet. Set user.name and user.email, or provide GIT_USER_NAME and"
+  log "WARNING: GIT_USER_EMAIL to the devcontainer environment. Commits need one; the rest of the"
+  log "WARNING: environment does not, so setup continues."
+fi
+
+# Signing is not configured here. post-start.sh runs on every start, including
+# the first one right after this hook, and that is where an SSH agent can
+# actually be expected to exist.
 
 log "Ensuring Go cache directories exist"
 sudo mkdir -p \

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -4,7 +4,12 @@ set -euo pipefail
 
 workspace_dir="${1:-${containerWorkspaceFolder:-${WORKSPACE_FOLDER:-$(pwd)}}}"
 
-bash "${workspace_dir}/.devcontainer/sync-signing-key.sh"
+# Refresh signing on every start: this is the first hook that can expect a
+# forwarded SSH agent, and a reconnect can change SSH_AUTH_SOCK or the loaded
+# key. The helper reports missing credentials rather than failing, and Git
+# itself is what refuses an unsigned commit, so startup never depends on them.
+bash "${workspace_dir}/.devcontainer/sync-signing-key.sh" ||
+  echo "[post-start] WARNING: sync-signing-key.sh failed; run it by hand to see why." >&2
 
 if [[ ! -f "${workspace_dir}/.env" ]]; then
   echo "hint: ${workspace_dir}/.env is absent; add GH_TOKEN there if you want read-only gh CLI access."

--- a/.devcontainer/sync-signing-key.sh
+++ b/.devcontainer/sync-signing-key.sh
@@ -1,59 +1,147 @@
 #!/usr/bin/env bash
 
+# Configure Git SSH commit signing against whatever the forwarded SSH agent
+# currently offers.
+#
+# The mandatory half of the policy is plain Git configuration, not shell logic:
+#
+#   commit.gpgsign=true            every commit is signed
+#   gpg.format=ssh                 signed with an SSH key
+#   gpg.ssh.defaultKeyCommand      the key comes from the live agent
+#
+# With those set and no agent, `git commit` fails on its own ("fatal: either
+# user.signingkey or gpg.ssh.defaultKeyCommand needs to be configured", or the
+# key command returning nothing). So this script never has to police commits,
+# and never has to fail a lifecycle hook to keep signing mandatory.
+#
+# What it adds on top is verification data: allowed_signers, which Git cannot
+# derive on its own.
+#
+# Idempotent and platform-neutral: safe on create, on every start and by hand,
+# and it leaves identity and credentials to whatever created the container.
+
 set -euo pipefail
 
 log() {
   echo "[sync-signing-key] $*"
 }
 
-fail() {
-  echo "[sync-signing-key] ERROR: $*" >&2
-  exit 1
+warn() {
+  echo "[sync-signing-key] WARNING: $*" >&2
 }
 
-git_name="$(git config --get user.name || true)"
-git_email="$(git config --get user.email || true)"
+# --- Generic baseline. Needs no Git identity and no SSH agent. ---------------
 
-if [ -z "${git_name}" ] || [ -z "${git_email}" ]; then
-  fail "Missing Git identity. Configure user.name and user.email before syncing SSH signing."
+# The policy this repository asserts: commits are signed. Always re-applied.
+git config --global commit.gpgsign true
+
+# Only fill in what is unset, so a developer or platform that has already
+# chosen a signing mechanism (an openpgp gpg.format, their own key command)
+# keeps it.
+if [ -z "$(git config --global --get gpg.format || true)" ]; then
+  git config --global gpg.format ssh
 fi
 
-if [ -z "${SSH_AUTH_SOCK:-}" ]; then
-  fail "SSH agent not available in the devcontainer. Start ssh-agent on your machine, load your key with ssh-add, then reopen the devcontainer."
+if [ -z "$(git config --global --get gpg.ssh.defaultKeyCommand || true)" ]; then
+  # Resolves the signing key from the agent at commit time. Nothing is cached,
+  # so a reconnect that changes SSH_AUTH_SOCK or swaps the loaded key needs no
+  # re-sync, and there is no stale key to go wrong.
+  git config --global gpg.ssh.defaultKeyCommand "ssh-add -L"
+fi
+
+# Earlier versions pinned user.signingkey to a public key file this script
+# wrote. That pin is stale the moment the agent offers a different key, and it
+# overrides the key command above. Retire it -- but only when it is still the
+# exact path this script used to manage, never a key someone else configured.
+legacy_key_file="${HOME}/.ssh/devcontainer_signing_key.pub"
+if [ "$(git config --global --get user.signingkey || true)" = "${legacy_key_file}" ]; then
+  log "Removing the pinned signing key; the agent now supplies it per commit"
+  git config --global --unset user.signingkey
+  rm -f "${legacy_key_file}"
+fi
+
+# --- Verification data. Needs both an identity and an agent. -----------------
+
+git_email="$(git config --get user.email || true)"
+if [ -z "${git_email}" ]; then
+  log "No Git identity configured yet; signing is enabled but allowed_signers is not written."
+  log "Configure user.email (or let the platform personalize Git), then re-run this script."
+  exit 0
 fi
 
 agent_keys_file="$(mktemp)"
 trap 'rm -f "${agent_keys_file}"' EXIT
 
-if ! ssh-add -L >"${agent_keys_file}" 2>/dev/null; then
-  fail "Could not read SSH keys from agent. Make sure your key is loaded on your machine with ssh-add, then reopen the devcontainer."
+if [ -n "${SSH_AUTH_SOCK:-}" ]; then
+  # ssh-add -L exits 1 when the agent holds no keys and 2 when it cannot be
+  # reached; neither is fatal here.
+  ssh-add -L >"${agent_keys_file}" 2>/dev/null || true
 fi
 
 if ! grep -qE '^ssh-' "${agent_keys_file}"; then
-  fail "SSH agent is running but has no keys loaded. Run ssh-add ~/.ssh/id_ed25519 on your machine, then reopen the devcontainer."
+  warn "No SSH key is available from an agent, so commits cannot be signed yet."
+  warn "Signing stays mandatory: git commit will fail until a key is loaded."
+  warn "Load one on your machine (ssh-add ~/.ssh/id_ed25519) and attach a session that forwards"
+  warn "the agent; refresh sooner with: bash .devcontainer/sync-signing-key.sh"
+  exit 0
 fi
 
-selected_pubkey="$(awk -v email="${git_email}" '$0 ~ email { print; exit }' "${agent_keys_file}")"
-if [ -z "${selected_pubkey}" ]; then
-  selected_pubkey="$(head -n 1 "${agent_keys_file}")"
-  log "No SSH key comment matched ${git_email}; using the first agent key"
+# Deterministic selection when the developer has expressed intent: a key whose
+# comment contains the Git email wins over agent order. index() is a literal
+# substring search -- an email used as a regex would treat its dots as
+# wildcards. With no match, gpg.ssh.defaultKeyCommand picks, which is both
+# simpler and immune to going stale.
+#
+# The pin is a literal key rather than a path, so there is no key file to
+# manage, and it is only ever written over an empty setting or a previous pin
+# of ours ("key::..."). A signing key configured by the developer or by the
+# platform that created this container is left alone.
+matched_key="$(awk -v email="${git_email}" '/^ssh-/ && index($0, email) { print; exit }' "${agent_keys_file}")"
+configured_key="$(git config --global --get user.signingkey || true)"
+own_pin=false
+if [ -z "${configured_key}" ] || [ "${configured_key#key::}" != "${configured_key}" ]; then
+  own_pin=true
+fi
+
+if [ "${own_pin}" = false ]; then
+  log "user.signingkey is set to something this script did not write; leaving it alone"
+elif [ -n "${matched_key}" ]; then
+  git config --global user.signingkey "key::${matched_key}"
+  log "Signing with the agent key whose comment matches ${git_email}"
 else
-  log "Using SSH key whose comment matches ${git_email}"
+  if [ -n "${configured_key}" ]; then
+    # A previous run matched, this one does not. Drop our pin rather than keep
+    # signing with a key the agent may no longer hold.
+    git config --global --unset user.signingkey
+  fi
+  key_count="$(grep -cE '^ssh-' "${agent_keys_file}")"
+  if [ "${key_count}" -gt 1 ]; then
+    warn "No agent key comment matches ${git_email} and ${key_count} keys are loaded;"
+    warn "the first one from ssh-add -L will sign. To choose deliberately, give the intended key a"
+    warn "comment containing ${git_email}: ssh-keygen -c -C \"${git_email}\" -f ~/.ssh/id_ed25519"
+  fi
 fi
 
-signing_key_path="${HOME}/.ssh/devcontainer_signing_key.pub"
+# allowed_signers principals are bare identities: "PRINCIPALS keytype base64
+# [comment]". A "Name <email>" principal is not valid there -- ssh-keygen -Y
+# rejects the line ("invalid key", "No principal matched"), so a correctly
+# signed commit fails to verify. The trailing key comment is valid and useful,
+# and is kept.
+#
+# Every key in the agent is listed, not just the signing one: they are all the
+# same developer's keys, and this keeps verification working for commits signed
+# before the pin above existed, or by whichever key the key command picks.
 allowed_signers_path="${HOME}/.config/git/allowed_signers"
-
-git config --global gpg.format ssh
-git config --global commit.gpgsign true
-
-mkdir -p "${HOME}/.config/git" "${HOME}/.ssh"
-printf '%s\n' "${selected_pubkey}" > "${signing_key_path}"
-chmod 600 "${signing_key_path}"
-git config --global user.signingkey "${signing_key_path}"
-
-printf '%s <%s> %s\n' "${git_name}" "${git_email}" "${selected_pubkey}" > "${allowed_signers_path}"
+mkdir -p "${HOME}/.config/git"
+awk -v email="${git_email}" '/^ssh-/ { print email, $0 }' "${agent_keys_file}" >"${allowed_signers_path}"
 chmod 600 "${allowed_signers_path}"
-git config --global gpg.ssh.allowedSignersFile "${allowed_signers_path}"
 
-log "Git SSH signing configuration refreshed"
+configured_signers="$(git config --global --get gpg.ssh.allowedSignersFile || true)"
+if [ -z "${configured_signers}" ] || [ "${configured_signers}" = "${allowed_signers_path}" ]; then
+  git config --global gpg.ssh.allowedSignersFile "${allowed_signers_path}"
+else
+  warn "gpg.ssh.allowedSignersFile points at ${configured_signers}; leaving it alone."
+  warn "Refreshed ${allowed_signers_path}, which is currently unused."
+fi
+
+log "Signing ready: $(grep -c '^ssh-' "${agent_keys_file}") agent key(s) trusted for ${git_email}"

--- a/.devcontainer/test-signing.sh
+++ b/.devcontainer/test-signing.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+
+# Tests for sync-signing-key.sh, run against a throwaway HOME, a disposable
+# ssh-agent and generated keys -- no developer key, identity or agent is
+# touched. Run it by hand after changing the signing scripts:
+#
+#   bash .devcontainer/test-signing.sh
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+sync_script="${script_dir}/sync-signing-key.sh"
+
+readonly TEST_EMAIL="user@example.com"
+
+sandbox="$(mktemp -d)"
+agent_pid=""
+
+cleanup() {
+  [ -n "${agent_pid}" ] && kill "${agent_pid}" 2>/dev/null
+  rm -rf "${sandbox}"
+}
+trap cleanup EXIT
+
+failures=0
+
+pass() { echo "  ok    - $*"; }
+fail() { echo "  FAIL  - $*" >&2; failures=$((failures + 1)); }
+
+check() {
+  local description="$1" expected="$2" actual="$3"
+  if [ "${expected}" = "${actual}" ]; then
+    pass "${description}"
+  else
+    fail "${description} (expected '${expected}', got '${actual}')"
+  fi
+}
+
+# Each case gets its own HOME so global Git config never leaks between them.
+new_home() {
+  local home="${sandbox}/home-$1"
+  mkdir -p "${home}"
+  if [ "${2:-}" = "with-identity" ]; then
+    HOME="${home}" git config --global user.name "Test User"
+    HOME="${home}" git config --global user.email "${TEST_EMAIL}"
+  fi
+  echo "${home}"
+}
+
+run_sync() {
+  local home="$1"
+  shift
+  local status=0
+  # cd somewhere without a repository so no repo-local config can supply the
+  # identity the case under test is meant to control.
+  ( cd "${sandbox}" && HOME="${home}" "$@" bash "${sync_script}" ) >"${sandbox}/out" 2>&1 || status=$?
+  echo "${status}"
+}
+
+git_cfg() {
+  HOME="$1" git config --global --get "$2" 2>/dev/null || true
+}
+
+# Commit in a scratch repo under the given HOME; echo the exit status.
+try_commit() {
+  local home="$1" repo="${sandbox}/repo-$2"
+  shift 2
+  local status=0
+  mkdir -p "${repo}"
+  (
+    cd "${repo}"
+    export HOME="${home}"
+    "$@" git init -q -b main
+    "$@" git commit -q --allow-empty -m "test commit"
+  ) >"${sandbox}/commit-out" 2>&1 || status=$?
+  echo "${status}"
+}
+
+echo "== disposable keys and ssh-agent =="
+ssh-keygen -q -t ed25519 -N '' -C 'first-key' -f "${sandbox}/k1"
+ssh-keygen -q -t ed25519 -N '' -C 'second-key' -f "${sandbox}/k2"
+eval "$(ssh-agent -s)" >/dev/null
+agent_pid="${SSH_AGENT_PID}"
+ssh-add -q "${sandbox}/k1"
+sock="${SSH_AUTH_SOCK}"
+
+echo
+echo "No Git identity: the environment still comes up"
+home_n="$(new_home noidentity)"
+check "exits 0" "0" "$(run_sync "${home_n}" env SSH_AUTH_SOCK="${sock}")"
+check "signing is still mandatory" "true" "$(git_cfg "${home_n}" commit.gpgsign)"
+check "no identity is invented" "" "$(git_cfg "${home_n}" user.email)"
+[ -f "${home_n}/.config/git/allowed_signers" ] \
+  && fail "wrote allowed_signers without an identity" \
+  || pass "no allowed_signers without an identity"
+
+echo
+echo "Identity, no SSH agent: pending, not a failure"
+home_c="$(new_home noagent with-identity)"
+check "exits 0" "0" "$(run_sync "${home_c}" env -u SSH_AUTH_SOCK)"
+check "signing is mandatory" "true" "$(git_cfg "${home_c}" commit.gpgsign)"
+check "gpg.format is ssh" "ssh" "$(git_cfg "${home_c}" gpg.format)"
+check "the key comes from the agent, not a pinned file" "ssh-add -L" \
+  "$(git_cfg "${home_c}" gpg.ssh.defaultKeyCommand)"
+check "no signing key is invented" "" "$(git_cfg "${home_c}" user.signingkey)"
+grep -q "commits cannot be signed yet" "${sandbox}/out" \
+  && pass "says signing credentials are unavailable" \
+  || fail "no diagnostic about missing credentials"
+
+# The load-bearing invariant: no credentials must mean a refused commit, not a
+# silently unsigned one. Git enforces this by itself.
+commit_status="$(try_commit "${home_c}" noagent env -u SSH_AUTH_SOCK)"
+[ "${commit_status}" -ne 0 ] \
+  && pass "git commit fails without a signing key (exit ${commit_status})" \
+  || fail "git commit succeeded without signing credentials"
+grep -qi "sign" "${sandbox}/commit-out" \
+  && pass "the commit failure names signing" \
+  || { fail "commit failure is not about signing"; sed 's/^/        /' "${sandbox}/commit-out" >&2; }
+
+echo
+echo "Identity and agent: signing configured"
+home_e="$(new_home agent with-identity)"
+check "exits 0" "0" "$(run_sync "${home_e}" env SSH_AUTH_SOCK="${sock}")"
+allowed_signers="${home_e}/.config/git/allowed_signers"
+check "allowed_signers is wired up" "${allowed_signers}" \
+  "$(git_cfg "${home_e}" gpg.ssh.allowedSignersFile)"
+check "principal is the bare Git email" "${TEST_EMAIL}" "$(awk 'NR==1 {print $1}' "${allowed_signers}")"
+check "the key comment is preserved" "first-key" "$(awk 'NR==1 {print $4}' "${allowed_signers}")"
+grep -q '<' "${allowed_signers}" \
+  && fail "allowed_signers still contains a 'Name <email>' principal" \
+  || pass "no 'Name <email>' principal"
+check "no key file is left on disk" "absent" \
+  "$([ -e "${home_e}/.ssh/devcontainer_signing_key.pub" ] && echo present || echo absent)"
+
+check "a commit signs" "0" "$(try_commit "${home_e}" agent env SSH_AUTH_SOCK="${sock}")"
+(
+  cd "${sandbox}/repo-agent"
+  HOME="${home_e}" SSH_AUTH_SOCK="${sock}" git log -1 --show-signature
+) >"${sandbox}/verify-out" 2>&1 || true
+grep -q "Good \"git\" signature for ${TEST_EMAIL}" "${sandbox}/verify-out" \
+  && pass "git log --show-signature verifies it for ${TEST_EMAIL}" \
+  || { fail "signature did not verify"; sed 's/^/        /' "${sandbox}/verify-out" >&2; }
+
+echo
+echo "Idempotency and reconnects"
+before="$(cat "${allowed_signers}")"
+check "a second run exits 0" "0" "$(run_sync "${home_e}" env SSH_AUTH_SOCK="${sock}")"
+check "allowed_signers is unchanged" "${before}" "$(cat "${allowed_signers}")"
+check "no ephemeral socket path is persisted" "" \
+  "$(grep -rl "${sock}" "${home_e}" 2>/dev/null | head -n 1)"
+check "an agent-less run afterwards still exits 0" "0" "$(run_sync "${home_e}" env -u SSH_AUTH_SOCK)"
+
+echo
+echo "A second agent key is added, neither matching the Git email"
+ssh-add -q "${sandbox}/k2"
+check "exits 0" "0" "$(run_sync "${home_e}" env SSH_AUTH_SOCK="${sock}")"
+check "no key is pinned when none matches" "" "$(git_cfg "${home_e}" user.signingkey)"
+grep -q "2 keys are loaded" "${sandbox}/out" \
+  && pass "warns which key will sign" \
+  || fail "no diagnostic about the ambiguity"
+check "both agent keys are trusted" "2" "$(wc -l <"${allowed_signers}" | tr -d ' ')"
+check "every line uses the email principal" "2" "$(awk -v e="${TEST_EMAIL}" '$1 == e' "${allowed_signers}" | wc -l | tr -d ' ')"
+check "a commit still verifies" "0" "$(try_commit "${home_e}" twokeys env SSH_AUTH_SOCK="${sock}")"
+(
+  cd "${sandbox}/repo-twokeys"
+  HOME="${home_e}" SSH_AUTH_SOCK="${sock}" git log -1 --show-signature
+) >"${sandbox}/verify2-out" 2>&1 || true
+grep -q "Good \"git\" signature for ${TEST_EMAIL}" "${sandbox}/verify2-out" \
+  && pass "whichever key was used verifies" \
+  || { fail "signature did not verify with two keys loaded"; sed 's/^/        /' "${sandbox}/verify2-out" >&2; }
+
+echo
+echo "A key whose comment matches the Git email is loaded"
+ssh-keygen -q -t ed25519 -N '' -C "${TEST_EMAIL}" -f "${sandbox}/k3"
+ssh-add -q "${sandbox}/k3"
+home_p="$(new_home pinned with-identity)"
+check "exits 0" "0" "$(run_sync "${home_p}" env SSH_AUTH_SOCK="${sock}")"
+matched_fingerprint="$(ssh-keygen -lf "${sandbox}/k3.pub" | awk '{print $2}')"
+check "the matching key is pinned, not agent order" "key::$(cat "${sandbox}/k3.pub" | sed 's/ *$//')" \
+  "$(git_cfg "${home_p}" user.signingkey)"
+check "a commit signs" "0" "$(try_commit "${home_p}" matched env SSH_AUTH_SOCK="${sock}")"
+(
+  cd "${sandbox}/repo-matched"
+  HOME="${home_p}" SSH_AUTH_SOCK="${sock}" git log -1 --show-signature
+) >"${sandbox}/verify3-out" 2>&1 || true
+grep -q "${matched_fingerprint}" "${sandbox}/verify3-out" \
+  && pass "the matching key is the one that signed" \
+  || { fail "a different key signed"; sed 's/^/        /' "${sandbox}/verify3-out" >&2; }
+grep -q "Good \"git\" signature for ${TEST_EMAIL}" "${sandbox}/verify3-out" \
+  && pass "and it verifies" \
+  || fail "the matched-key signature did not verify"
+
+echo
+echo "The matching key is unloaded again"
+ssh-add -qd "${sandbox}/k3" 2>/dev/null
+check "exits 0" "0" "$(run_sync "${home_p}" env SSH_AUTH_SOCK="${sock}")"
+check "our stale pin is dropped" "" "$(git_cfg "${home_p}" user.signingkey)"
+check "commits still work via the key command" "0" \
+  "$(try_commit "${home_p}" unpinned env SSH_AUTH_SOCK="${sock}")"
+
+echo
+echo "Migration off a previously pinned signing key"
+home_l="$(new_home legacy with-identity)"
+mkdir -p "${home_l}/.ssh"
+ssh-add -L | head -n1 >"${home_l}/.ssh/devcontainer_signing_key.pub"
+HOME="${home_l}" git config --global user.signingkey "${home_l}/.ssh/devcontainer_signing_key.pub"
+check "exits 0" "0" "$(run_sync "${home_l}" env SSH_AUTH_SOCK="${sock}")"
+check "the stale pin is removed" "" "$(git_cfg "${home_l}" user.signingkey)"
+check "the file it pinned is gone" "absent" \
+  "$([ -e "${home_l}/.ssh/devcontainer_signing_key.pub" ] && echo present || echo absent)"
+
+echo
+echo "Configuration this script does not own is left alone"
+home_o="$(new_home owned with-identity)"
+HOME="${home_o}" git config --global gpg.format openpgp
+HOME="${home_o}" git config --global user.signingkey "SOMEONE-ELSES-KEY"
+check "exits 0" "0" "$(run_sync "${home_o}" env SSH_AUTH_SOCK="${sock}")"
+check "an existing gpg.format is kept" "openpgp" "$(git_cfg "${home_o}" gpg.format)"
+check "a foreign signing key is kept" "SOMEONE-ELSES-KEY" "$(git_cfg "${home_o}" user.signingkey)"
+grep -q "did not write; leaving it alone" "${sandbox}/out" \
+  && pass "says why it left the key alone" \
+  || fail "no diagnostic about the foreign key"
+
+echo
+if [ "${failures}" -eq 0 ]; then
+  echo "All signing tests passed."
+else
+  echo "${failures} signing test(s) failed." >&2
+  exit 1
+fi

--- a/test/e2e/Taskfile-e2e.yml
+++ b/test/e2e/Taskfile-e2e.yml
@@ -822,6 +822,32 @@ tasks:
 
   _cluster-ready:
     method: timestamp
+    # The stamps below only prove a PAST run succeeded; they say nothing about
+    # the cluster right now. A cluster left wedged by a host suspend/resume or
+    # OOM (clock-skewed node certs, agents NotReady) keeps its stamp, so every
+    # task depending on this one reads "up to date" and the run sails straight
+    # into the suite, which then hangs until the 30m ginkgo timeout. Probe the
+    # live cluster instead, and abort with the cleanup instructions.
+    #
+    # Preconditions are evaluated before status, and unlike a status entry a
+    # failing one stops the run instead of re-running start-cluster.sh — which
+    # would only re-derive the same verdict, slowly, inside its retry loop.
+    # `test -f .../ready || exit 0` keeps the very first run (nothing stamped,
+    # no cluster yet) out of the way. 5s is a generous budget for one GET
+    # against a healthy apiserver; if it cannot answer in that time the cluster
+    # is not fit to run e2e against.
+    preconditions:
+      - sh: |
+          test -f "{{.CS}}/ready" || exit 0
+          kubectl --context "{{.CTX}}" --request-timeout=5s get nodes \
+            -o jsonpath='{range .items[*]}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' 2>/dev/null \
+            | awk 'BEGIN{n=0;t=0} {t++; if ($0=="True") n++} END{exit !(t>0 && n==t)}'
+        msg: |
+          Cluster '{{.CLUSTER_NAME}}' is stamped as ready but did not report all nodes Ready within 5s.
+          It is wedged (host suspend/resume, OOM, or a killed run) — a fresh cluster answers instantly.
+
+          Cleanup and retry:
+            task clean-cluster
     deps:
       # Probe ghcr.io reachability before building the cluster (see _ghcr-preflight).
       - _ghcr-preflight
@@ -843,7 +869,7 @@ tasks:
         export CLUSTER_NAME="{{.CLUSTER_NAME}}"
         export AUDIT_DIR_REL="{{.AUDIT_ASSET_DIR}}"
         bash test/e2e/cluster/start-cluster.sh
-        kubectl --context "{{.CTX}}" get ns >/dev/null
+        kubectl --context "{{.CTX}}" --request-timeout=5s get ns >/dev/null
         touch "{{.CS}}/ready"
 
   _flux-installed:

--- a/test/e2e/cluster/start-cluster.sh
+++ b/test/e2e/cluster/start-cluster.sh
@@ -76,11 +76,11 @@ cluster_is_healthy() {
         return 1
     fi
 
-    kubectl --context "${context_name}" --request-timeout=10s get ns >/dev/null 2>&1 || return 1
+    kubectl --context "${context_name}" --request-timeout=5s get ns >/dev/null 2>&1 || return 1
 
     local expected_nodes
     expected_nodes="$((K3D_AGENT_COUNT + 1))"
-    kubectl --context "${context_name}" --request-timeout=10s get nodes \
+    kubectl --context "${context_name}" --request-timeout=5s get nodes \
         -o jsonpath='{range .items[*]}{.metadata.name}{" "}{range .status.conditions[?(@.type=="Ready")]}{.status}{end}{"\n"}{end}' \
         2>/dev/null \
         | awk -v expected="${expected_nodes}" '
@@ -352,7 +352,7 @@ main() {
         exit 1
     fi
 
-    kubectl --context "$(cluster_context_name)" --request-timeout=30s get ns >/dev/null
+    kubectl --context "$(cluster_context_name)" --request-timeout=5s get ns >/dev/null
 
     echo "⏳ Waiting for full API discovery to be healthy (aggregated APIServices ready)..."
     if ! wait_discovery_healthy; then


### PR DESCRIPTION
Two independent improvements to the development environment.

## 1. e2e: fail fast when a stamped cluster is wedged

`.stamps/cluster/<ctx>/ready` only proves a *past* bring-up succeeded. A cluster left wedged by a host suspend/resume or OOM keeps its stamp, so every task depending on `_cluster-ready` reads "up to date", the run walks straight into the suite, and `task test-e2e` hangs until the 30m ginkgo timeout with no useful message.

A live probe now runs as a `preconditions:` entry on `_cluster-ready`. As a `status:` entry a failed probe would only re-run `start-cluster.sh`, which then re-derives the same verdict slowly inside its 60-attempt retry loop; as a precondition it aborts immediately with the cleanup instructions:

```
task: Cluster 'gitops-reverser-test-e2e' is stamped as ready but did not report all nodes Ready within 5s.
It is wedged (host suspend/resume, OOM, or a killed run) — a fresh cluster answers instantly.

Cleanup and retry:
  task clean-cluster
```

`test -f .../ready || exit 0` keeps the first run (nothing stamped, no cluster yet) out of the way. The health-path kubectl timeouts in `start-cluster.sh` drop to 5s, and the post-bring-up sanity `get ns` gains a timeout, so no step in the bring-up graph can hang unbounded.

## 2. devcontainer: let Git enforce signing, and decouple it from container creation

Creating a usable environment, personalizing Git, and having signing credentials available are three separate things. The scripts treated them as one — `post-create.sh` required an identity and `sync-signing-key.sh` required a forwarded SSH agent, both under `set -e` — so a container created before any interactive session attaches could never finish creating.

Signing stays mandatory, enforced by plain Git configuration rather than shell logic:

```
commit.gpgsign=true
gpg.format=ssh
gpg.ssh.defaultKeyCommand=ssh-add -L
```

A commit with no key reachable then fails on its own (`fatal: either user.signingkey or gpg.ssh.defaultKeyCommand needs to be configured`), so no hook has to fail to keep unsigned commits impossible.

That removes the custom credential logic: the key is read from the live agent per commit, so the pinned `user.signingkey`, the public key file the script used to write, and the key-selection algorithm are gone — along with the class of bug where a reconnect left the pin stale.

**Bug fix:** `allowed_signers` used a `Name <email>` principal. That file takes bare identities, so `ssh-keygen` rejected the line and a correctly signed commit failed to verify with `allowed_signers:1: invalid key` / `No principal matched`. It is now the Git email, with the key comment kept.

Identity keeps its existing Git-config-then-`GIT_USER_NAME`/`GIT_USER_EMAIL` precedence and is a warning rather than a hard stop. `gpg.format`, `gpg.ssh.defaultKeyCommand` and `gpg.ssh.allowedSignersFile` are only filled in when unset, so a developer or platform that has already chosen a signing mechanism keeps it. Nothing platform-specific is added.

Closes #182. That issue asks for Git to be simpler for first-time devs, who were expected to set `GIT_USER_NAME` and `GIT_USER_EMAIL`. They are no longer expected to: a container with no identity at all now builds, starts, and runs the test suite, and only a `git commit` requires one. The two `${localEnv:...}` lines stay as an optional fallback for containers created outside VS Code, where nothing else supplies an identity — they are now a convenience rather than a requirement.

## 3. devcontainer: keep the gh CLI logged in across rebuilds

`~/.config/gh` was not among the persisted volumes, so every rebuild dropped the token and `gh` went back to asking for `gh auth login`. It is now a named volume (`ghconfig`), handled the same way `.claude`, `.codex` and `.kube` already are. Independent of the signing work and separable as its own commit.

## Validation

- `bash .devcontainer/test-signing.sh` — 34/34 checks, against a disposable ssh-agent and generated keys
- `task lint` — pass
- `task test` — pass (coverage 76.7%, unchanged)
- `task test-e2e` — pass, 71/94 specs, 0 failed (23 skipped are the opt-in corners the default label filter excludes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

