### PR TITLE
fix(devcontainer): configure verification for an externally supplied signing key

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -86,8 +86,13 @@ keys currently in the agent so `git log --show-signature` can verify. It runs fr
 
 If one of the agent keys has a comment containing your Git email, that key is pinned as
 `user.signingkey` so selection does not depend on agent order. With no such key the pin is left
-unset, which is both simpler and immune to going stale. A signing key you configured yourself is
-never overwritten.
+unset, which is both simpler and immune to going stale.
+
+A `user.signingkey` that something else configured takes precedence over the agent and is never
+replaced — a platform that manages its own key file did that deliberately. In that case the helper
+needs no SSH agent at all: it derives the public key (a `*.pub` path directly, or the `<key>.pub`
+beside a private key — the private key is never read) and writes `allowed_signers` for it, so an
+already-signing setup gains local verification without its signing key changing.
 
 [`post-create.sh`](./post-create.sh) does not configure signing. Creating the environment,
 personalizing Git, and having credentials available are three separate things, and only the first

--- a/.devcontainer/sync-signing-key.sh
+++ b/.devcontainer/sync-signing-key.sh
@@ -109,22 +109,42 @@ public_key_for_signingkey() {
   return 1
 }
 
+# Ownership is recorded explicitly rather than inferred from the value. "key::"
+# is the documented way for ANYONE to configure a literal signing key, so
+# treating that prefix as a signature of this script would let it replace or
+# unset a key a platform deliberately configured.
+managed_key_marker="devcontainer.managedSigningKey"
+
 configured_key="$(git config --global --get user.signingkey || true)"
+managed_key="$(git config --global --get "${managed_key_marker}" || true)"
 own_pin=false
-if [ -z "${configured_key}" ] || [ "${configured_key#key::}" != "${configured_key}" ]; then
-  # Unset, or a literal pin this script wrote: ours to manage from the agent.
+if [ -z "${configured_key}" ] || [ "${configured_key}" = "${managed_key}" ]; then
+  # Unset, or the exact value this script last wrote: ours to manage.
   own_pin=true
 fi
 
 trusted_keys_file="$(mktemp)"
 trap 'rm -f "${trusted_keys_file}"' EXIT
 
+# keep_public_keys filters a key listing down to well-formed public key lines.
+# Matching on the base64 blob rather than on a "ssh-" prefix keeps ecdsa-*,
+# sk-ssh-* and sk-ecdsa-* keys, which are valid for both signing and
+# allowed_signers.
+keep_public_keys() {
+  local file="$1" tmp
+  tmp="$(mktemp)"
+  awk '$2 ~ /^AAAA/' "${file}" >"${tmp}"
+  mv "${tmp}" "${file}"
+}
+
 if [ "${own_pin}" = false ]; then
   # An externally configured signing key wins over the agent. A platform may
   # deliberately configure a key before invoking this script, and the whole
   # point of that is for it to be used -- so it is never replaced here, and no
   # agent is required. Only verification is added.
-  if public_key_for_signingkey "${configured_key}" >"${trusted_keys_file}"; then
+  public_key_for_signingkey "${configured_key}" >"${trusted_keys_file}" || true
+  keep_public_keys "${trusted_keys_file}"
+  if [ -s "${trusted_keys_file}" ]; then
     log "Using the signing key already configured at ${configured_key}"
   else
     warn "user.signingkey is ${configured_key}, but no public key could be derived from it."
@@ -139,7 +159,8 @@ else
     ssh-add -L >"${trusted_keys_file}" 2>/dev/null || true
   fi
 
-  if ! grep -qE '^ssh-' "${trusted_keys_file}"; then
+  keep_public_keys "${trusted_keys_file}"
+  if [ ! -s "${trusted_keys_file}" ]; then
     warn "No signing key is available: no user.signingkey is configured and no SSH agent key was found."
     warn "Signing stays mandatory: git commit will fail until a key is available."
     warn "Either load one on your machine (ssh-add ~/.ssh/id_ed25519) and attach a session that"
@@ -158,17 +179,19 @@ else
   # manage, and it is only ever written over an empty setting or a previous pin
   # of ours ("key::..."). A signing key configured by the developer or by the
   # platform that created this container is left alone.
-  matched_key="$(awk -v email="${git_email}" '/^ssh-/ && index($0, email) { print; exit }' "${trusted_keys_file}")"
+  matched_key="$(awk -v email="${git_email}" 'index($0, email) { print; exit }' "${trusted_keys_file}")"
   if [ -n "${matched_key}" ]; then
     git config --global user.signingkey "key::${matched_key}"
+    git config --global "${managed_key_marker}" "key::${matched_key}"
     log "Signing with the agent key whose comment matches ${git_email}"
   else
     if [ -n "${configured_key}" ]; then
-      # A previous run matched, this one does not. Drop our pin rather than keep
-      # signing with a key the agent may no longer hold.
+      # A previous run of OURS matched, this one does not. Drop the pin rather
+      # than keep signing with a key the agent may no longer hold.
       git config --global --unset user.signingkey
+      git config --global --unset "${managed_key_marker}" 2>/dev/null || true
     fi
-    key_count="$(grep -cE '^ssh-' "${trusted_keys_file}")"
+    key_count="$(wc -l <"${trusted_keys_file}" | tr -d ' ')"
     if [ "${key_count}" -gt 1 ]; then
       warn "No agent key comment matches ${git_email} and ${key_count} keys are loaded;"
       warn "the first one from ssh-add -L will sign. To choose deliberately, give the intended key a"
@@ -189,7 +212,7 @@ fi
 # that one key, which is the only thing that can sign.
 allowed_signers_path="${HOME}/.config/git/allowed_signers"
 mkdir -p "${HOME}/.config/git"
-awk -v email="${git_email}" '/^ssh-/ { print email, $0 }' "${trusted_keys_file}" >"${allowed_signers_path}"
+awk -v email="${git_email}" '{ print email, $0 }' "${trusted_keys_file}" >"${allowed_signers_path}"
 chmod 600 "${allowed_signers_path}"
 
 configured_signers="$(git config --global --get gpg.ssh.allowedSignersFile || true)"

--- a/.devcontainer/sync-signing-key.sh
+++ b/.devcontainer/sync-signing-key.sh
@@ -15,7 +15,13 @@
 # and never has to fail a lifecycle hook to keep signing mandatory.
 #
 # What it adds on top is verification data: allowed_signers, which Git cannot
-# derive on its own.
+# derive on its own -- for whichever signing key is actually in play. Two are
+# supported, in this order:
+#
+#   1. a user.signingkey the environment configured (a platform that manages
+#      its own key file, a developer who chose one). It is preserved as-is and
+#      needs no SSH agent.
+#   2. a key from a forwarded SSH agent, the usual VS Code flow.
 #
 # Idempotent and platform-neutral: safe on create, on every start and by hand,
 # and it leaves identity and credentials to whatever created the container.
@@ -60,7 +66,7 @@ if [ "$(git config --global --get user.signingkey || true)" = "${legacy_key_file
   rm -f "${legacy_key_file}"
 fi
 
-# --- Verification data. Needs both an identity and an agent. -----------------
+# --- Verification data. Needs an identity and a key source. ------------------
 
 git_email="$(git config --get user.email || true)"
 if [ -z "${git_email}" ]; then
@@ -69,56 +75,105 @@ if [ -z "${git_email}" ]; then
   exit 0
 fi
 
-agent_keys_file="$(mktemp)"
-trap 'rm -f "${agent_keys_file}"' EXIT
+# --- Resolve the public key(s) to trust ---------------------------------------
 
-if [ -n "${SSH_AUTH_SOCK:-}" ]; then
-  # ssh-add -L exits 1 when the agent holds no keys and 2 when it cannot be
-  # reached; neither is fatal here.
-  ssh-add -L >"${agent_keys_file}" 2>/dev/null || true
-fi
+# public_key_for_signingkey prints the public key line for a configured
+# user.signingkey, or nothing when it cannot be derived. Only ever reads public
+# key material: for a private key path it reads the sibling .pub, never the key.
+public_key_for_signingkey() {
+  local value="$1"
 
-if ! grep -qE '^ssh-' "${agent_keys_file}"; then
-  warn "No SSH key is available from an agent, so commits cannot be signed yet."
-  warn "Signing stays mandatory: git commit will fail until a key is loaded."
-  warn "Load one on your machine (ssh-add ~/.ssh/id_ed25519) and attach a session that forwards"
-  warn "the agent; refresh sooner with: bash .devcontainer/sync-signing-key.sh"
-  exit 0
-fi
+  # A literal key, which is what this script pins for an agent key.
+  if [ "${value#key::}" != "${value}" ]; then
+    printf '%s\n' "${value#key::}"
+    return 0
+  fi
 
-# Deterministic selection when the developer has expressed intent: a key whose
-# comment contains the Git email wins over agent order. index() is a literal
-# substring search -- an email used as a regex would treat its dots as
-# wildcards. With no match, gpg.ssh.defaultKeyCommand picks, which is both
-# simpler and immune to going stale.
-#
-# The pin is a literal key rather than a path, so there is no key file to
-# manage, and it is only ever written over an empty setting or a previous pin
-# of ours ("key::..."). A signing key configured by the developer or by the
-# platform that created this container is left alone.
-matched_key="$(awk -v email="${git_email}" '/^ssh-/ && index($0, email) { print; exit }' "${agent_keys_file}")"
+  # A path to a public key.
+  case "${value}" in
+    *.pub)
+      if [ -r "${value}" ]; then
+        head -n 1 "${value}"
+        return 0
+      fi
+      return 1
+      ;;
+  esac
+
+  # A path to a private key: the public half sits beside it by convention.
+  if [ -r "${value}.pub" ]; then
+    head -n 1 "${value}.pub"
+    return 0
+  fi
+
+  return 1
+}
+
 configured_key="$(git config --global --get user.signingkey || true)"
 own_pin=false
 if [ -z "${configured_key}" ] || [ "${configured_key#key::}" != "${configured_key}" ]; then
+  # Unset, or a literal pin this script wrote: ours to manage from the agent.
   own_pin=true
 fi
 
+trusted_keys_file="$(mktemp)"
+trap 'rm -f "${trusted_keys_file}"' EXIT
+
 if [ "${own_pin}" = false ]; then
-  log "user.signingkey is set to something this script did not write; leaving it alone"
-elif [ -n "${matched_key}" ]; then
-  git config --global user.signingkey "key::${matched_key}"
-  log "Signing with the agent key whose comment matches ${git_email}"
-else
-  if [ -n "${configured_key}" ]; then
-    # A previous run matched, this one does not. Drop our pin rather than keep
-    # signing with a key the agent may no longer hold.
-    git config --global --unset user.signingkey
+  # An externally configured signing key wins over the agent. A platform may
+  # deliberately configure a key before invoking this script, and the whole
+  # point of that is for it to be used -- so it is never replaced here, and no
+  # agent is required. Only verification is added.
+  if public_key_for_signingkey "${configured_key}" >"${trusted_keys_file}"; then
+    log "Using the signing key already configured at ${configured_key}"
+  else
+    warn "user.signingkey is ${configured_key}, but no public key could be derived from it."
+    warn "Expected either a readable *.pub, or a sibling <key>.pub next to a private key."
+    warn "Signing is left exactly as configured; local verification is not set up."
+    exit 0
   fi
-  key_count="$(grep -cE '^ssh-' "${agent_keys_file}")"
-  if [ "${key_count}" -gt 1 ]; then
-    warn "No agent key comment matches ${git_email} and ${key_count} keys are loaded;"
-    warn "the first one from ssh-add -L will sign. To choose deliberately, give the intended key a"
-    warn "comment containing ${git_email}: ssh-keygen -c -C \"${git_email}\" -f ~/.ssh/id_ed25519"
+else
+  if [ -n "${SSH_AUTH_SOCK:-}" ]; then
+    # ssh-add -L exits 1 when the agent holds no keys and 2 when it cannot be
+    # reached; neither is fatal here.
+    ssh-add -L >"${trusted_keys_file}" 2>/dev/null || true
+  fi
+
+  if ! grep -qE '^ssh-' "${trusted_keys_file}"; then
+    warn "No signing key is available: no user.signingkey is configured and no SSH agent key was found."
+    warn "Signing stays mandatory: git commit will fail until a key is available."
+    warn "Either load one on your machine (ssh-add ~/.ssh/id_ed25519) and attach a session that"
+    warn "forwards the agent, or configure user.signingkey; then re-run:"
+    warn "  bash .devcontainer/sync-signing-key.sh"
+    exit 0
+  fi
+
+  # Deterministic selection when the developer has expressed intent: a key whose
+  # comment contains the Git email wins over agent order. index() is a literal
+  # substring search -- an email used as a regex would treat its dots as
+  # wildcards. With no match, gpg.ssh.defaultKeyCommand picks, which is both
+  # simpler and immune to going stale.
+  #
+  # The pin is a literal key rather than a path, so there is no key file to
+  # manage, and it is only ever written over an empty setting or a previous pin
+  # of ours ("key::..."). A signing key configured by the developer or by the
+  # platform that created this container is left alone.
+  matched_key="$(awk -v email="${git_email}" '/^ssh-/ && index($0, email) { print; exit }' "${trusted_keys_file}")"
+  if [ -n "${matched_key}" ]; then
+    git config --global user.signingkey "key::${matched_key}"
+    log "Signing with the agent key whose comment matches ${git_email}"
+  else
+    if [ -n "${configured_key}" ]; then
+      # A previous run matched, this one does not. Drop our pin rather than keep
+      # signing with a key the agent may no longer hold.
+      git config --global --unset user.signingkey
+    fi
+    key_count="$(grep -cE '^ssh-' "${trusted_keys_file}")"
+    if [ "${key_count}" -gt 1 ]; then
+      warn "No agent key comment matches ${git_email} and ${key_count} keys are loaded;"
+      warn "the first one from ssh-add -L will sign. To choose deliberately, give the intended key a"
+      warn "comment containing ${git_email}: ssh-keygen -c -C \"${git_email}\" -f ~/.ssh/id_ed25519"
+    fi
   fi
 fi
 
@@ -128,12 +183,13 @@ fi
 # signed commit fails to verify. The trailing key comment is valid and useful,
 # and is kept.
 #
-# Every key in the agent is listed, not just the signing one: they are all the
-# same developer's keys, and this keeps verification working for commits signed
-# before the pin above existed, or by whichever key the key command picks.
+# For the agent case every loaded key is listed, not just the signing one:
+# they are all the same developer's keys, and it keeps verification working
+# whichever one the key command picks. For an externally configured key it is
+# that one key, which is the only thing that can sign.
 allowed_signers_path="${HOME}/.config/git/allowed_signers"
 mkdir -p "${HOME}/.config/git"
-awk -v email="${git_email}" '/^ssh-/ { print email, $0 }' "${agent_keys_file}" >"${allowed_signers_path}"
+awk -v email="${git_email}" '/^ssh-/ { print email, $0 }' "${trusted_keys_file}" >"${allowed_signers_path}"
 chmod 600 "${allowed_signers_path}"
 
 configured_signers="$(git config --global --get gpg.ssh.allowedSignersFile || true)"
@@ -144,4 +200,4 @@ else
   warn "Refreshed ${allowed_signers_path}, which is currently unused."
 fi
 
-log "Signing ready: $(grep -c '^ssh-' "${agent_keys_file}") agent key(s) trusted for ${git_email}"
+log "Signing ready: $(wc -l <"${allowed_signers_path}" | tr -d ' ') key(s) trusted for ${git_email}"

--- a/.devcontainer/test-signing.sh
+++ b/.devcontainer/test-signing.sh
@@ -103,7 +103,7 @@ check "gpg.format is ssh" "ssh" "$(git_cfg "${home_c}" gpg.format)"
 check "the key comes from the agent, not a pinned file" "ssh-add -L" \
   "$(git_cfg "${home_c}" gpg.ssh.defaultKeyCommand)"
 check "no signing key is invented" "" "$(git_cfg "${home_c}" user.signingkey)"
-grep -q "commits cannot be signed yet" "${sandbox}/out" \
+grep -q "No signing key is available" "${sandbox}/out" \
   && pass "says signing credentials are unavailable" \
   || fail "no diagnostic about missing credentials"
 
@@ -126,6 +126,9 @@ check "allowed_signers is wired up" "${allowed_signers}" \
   "$(git_cfg "${home_e}" gpg.ssh.allowedSignersFile)"
 check "principal is the bare Git email" "${TEST_EMAIL}" "$(awk 'NR==1 {print $1}' "${allowed_signers}")"
 check "the key comment is preserved" "first-key" "$(awk 'NR==1 {print $4}' "${allowed_signers}")"
+grep -q "Signing ready: 1 key(s) trusted for ${TEST_EMAIL}" "${sandbox}/out" \
+  && pass "reports how many keys are trusted" \
+  || { fail "wrong trusted-key count"; grep "Signing ready" "${sandbox}/out" | sed 's/^/        /' >&2; }
 grep -q '<' "${allowed_signers}" \
   && fail "allowed_signers still contains a 'Name <email>' principal" \
   || pass "no 'Name <email>' principal"
@@ -210,6 +213,73 @@ check "the file it pinned is gone" "absent" \
   "$([ -e "${home_l}/.ssh/devcontainer_signing_key.pub" ] && echo present || echo absent)"
 
 echo
+echo "An externally configured signing key, private-key path, no agent"
+home_x="$(new_home external with-identity)"
+mkdir -p "${home_x}/.ssh/managed"
+ssh-keygen -q -t ed25519 -N '' -C 'platform-managed' -f "${home_x}/.ssh/managed/platform"
+HOME="${home_x}" git config --global user.signingkey "${home_x}/.ssh/managed/platform"
+check "exits 0" "0" "$(run_sync "${home_x}" env -u SSH_AUTH_SOCK)"
+check "the external signing key is preserved" "${home_x}/.ssh/managed/platform" \
+  "$(git_cfg "${home_x}" user.signingkey)"
+check "allowedSignersFile is configured" "${home_x}/.config/git/allowed_signers" \
+  "$(git_cfg "${home_x}" gpg.ssh.allowedSignersFile)"
+check "gpg.format is ssh" "ssh" "$(git_cfg "${home_x}" gpg.format)"
+check "signing stays mandatory" "true" "$(git_cfg "${home_x}" commit.gpgsign)"
+check "allowed_signers principal is the bare Git email" "${TEST_EMAIL}" \
+  "$(awk 'NR==1 {print $1}' "${home_x}/.config/git/allowed_signers")"
+check "it trusts the .pub beside the private key" "platform-managed" \
+  "$(awk 'NR==1 {print $4}' "${home_x}/.config/git/allowed_signers")"
+
+# The real-world check: signs with no agent at all, and now verifies too.
+check "a commit signs with no agent" "0" "$(try_commit "${home_x}" external env -u SSH_AUTH_SOCK)"
+(
+  cd "${sandbox}/repo-external"
+  HOME="${home_x}" env -u SSH_AUTH_SOCK git log -1 --show-signature
+) >"${sandbox}/verify-ext" 2>&1 || true
+grep -q "Good \"git\" signature for ${TEST_EMAIL}" "${sandbox}/verify-ext" \
+  && pass "and git log --show-signature verifies it" \
+  || { fail "external-key signature did not verify"; sed 's/^/        /' "${sandbox}/verify-ext" >&2; }
+
+echo
+echo "An externally configured signing key given as a .pub path"
+home_xp="$(new_home externalpub with-identity)"
+mkdir -p "${home_xp}/.ssh"
+ssh-keygen -q -t ed25519 -N '' -C 'pub-path' -f "${home_xp}/.ssh/direct"
+HOME="${home_xp}" git config --global user.signingkey "${home_xp}/.ssh/direct.pub"
+check "exits 0" "0" "$(run_sync "${home_xp}" env -u SSH_AUTH_SOCK)"
+check "the .pub path is preserved" "${home_xp}/.ssh/direct.pub" "$(git_cfg "${home_xp}" user.signingkey)"
+check "it is used directly" "pub-path" \
+  "$(awk 'NR==1 {print $4}' "${home_xp}/.config/git/allowed_signers")"
+
+echo
+echo "An external key wins over a present SSH agent"
+home_xa="$(new_home externalagent with-identity)"
+mkdir -p "${home_xa}/.ssh"
+ssh-keygen -q -t ed25519 -N '' -C 'external-wins' -f "${home_xa}/.ssh/ext"
+HOME="${home_xa}" git config --global user.signingkey "${home_xa}/.ssh/ext"
+check "exits 0" "0" "$(run_sync "${home_xa}" env SSH_AUTH_SOCK="${sock}")"
+check "the external key is not replaced by an agent key" "${home_xa}/.ssh/ext" \
+  "$(git_cfg "${home_xa}" user.signingkey)"
+check "allowed_signers trusts the external key" "external-wins" \
+  "$(awk 'NR==1 {print $4}' "${home_xa}/.config/git/allowed_signers")"
+check "only the external key is trusted" "1" \
+  "$(wc -l <"${home_xa}/.config/git/allowed_signers" | tr -d ' ')"
+before_ext="$(cat "${home_xa}/.config/git/allowed_signers")"
+check "re-running is idempotent" "0" "$(run_sync "${home_xa}" env SSH_AUTH_SOCK="${sock}")"
+check "allowed_signers is unchanged" "${before_ext}" "$(cat "${home_xa}/.config/git/allowed_signers")"
+
+echo
+echo "An external signing key whose public half cannot be found"
+home_xb="$(new_home externalbroken with-identity)"
+HOME="${home_xb}" git config --global user.signingkey "/nonexistent/key"
+check "exits 0" "0" "$(run_sync "${home_xb}" env -u SSH_AUTH_SOCK)"
+check "the configured key is still preserved" "/nonexistent/key" "$(git_cfg "${home_xb}" user.signingkey)"
+check "signing stays mandatory" "true" "$(git_cfg "${home_xb}" commit.gpgsign)"
+[ -f "${home_xb}/.config/git/allowed_signers" ] \
+  && fail "wrote allowed_signers for an underivable key" \
+  || pass "writes no bogus allowed_signers"
+
+echo
 echo "Configuration this script does not own is left alone"
 home_o="$(new_home owned with-identity)"
 HOME="${home_o}" git config --global gpg.format openpgp
@@ -217,9 +287,6 @@ HOME="${home_o}" git config --global user.signingkey "SOMEONE-ELSES-KEY"
 check "exits 0" "0" "$(run_sync "${home_o}" env SSH_AUTH_SOCK="${sock}")"
 check "an existing gpg.format is kept" "openpgp" "$(git_cfg "${home_o}" gpg.format)"
 check "a foreign signing key is kept" "SOMEONE-ELSES-KEY" "$(git_cfg "${home_o}" user.signingkey)"
-grep -q "did not write; leaving it alone" "${sandbox}/out" \
-  && pass "says why it left the key alone" \
-  || fail "no diagnostic about the foreign key"
 
 echo
 if [ "${failures}" -eq 0 ]; then

--- a/.devcontainer/test-signing.sh
+++ b/.devcontainer/test-signing.sh
@@ -194,10 +194,18 @@ grep -q "Good \"git\" signature for ${TEST_EMAIL}" "${sandbox}/verify3-out" \
   || fail "the matched-key signature did not verify"
 
 echo
+echo "The pin this script writes is recognised as its own on a later run"
+check "a pin was written" "key::$(ssh-add -L | grep "${TEST_EMAIL}" | sed 's/ *$//')" \
+  "$(git_cfg "${home_p}" user.signingkey)"
+check "ownership is recorded explicitly" "$(git_cfg "${home_p}" user.signingkey)" \
+  "$(git_cfg "${home_p}" devcontainer.managedSigningKey)"
+
+echo
 echo "The matching key is unloaded again"
 ssh-add -qd "${sandbox}/k3" 2>/dev/null
 check "exits 0" "0" "$(run_sync "${home_p}" env SSH_AUTH_SOCK="${sock}")"
 check "our stale pin is dropped" "" "$(git_cfg "${home_p}" user.signingkey)"
+check "and its ownership marker with it" "" "$(git_cfg "${home_p}" devcontainer.managedSigningKey)"
 check "commits still work via the key command" "0" \
   "$(try_commit "${home_p}" unpinned env SSH_AUTH_SOCK="${sock}")"
 
@@ -278,6 +286,39 @@ check "signing stays mandatory" "true" "$(git_cfg "${home_xb}" commit.gpgsign)"
 [ -f "${home_xb}/.config/git/allowed_signers" ] \
   && fail "wrote allowed_signers for an underivable key" \
   || pass "writes no bogus allowed_signers"
+
+echo
+echo "An external key given as a literal key:: value, with an agent present"
+# key:: is the documented way for ANYONE to configure a literal key, so it must
+# not be mistaken for a pin this script wrote.
+home_kl="$(new_home keyliteral with-identity)"
+ssh-keygen -q -t ed25519 -N '' -C 'platform-literal' -f "${sandbox}/kl"
+HOME="${home_kl}" git config --global user.signingkey "key::$(cat "${sandbox}/kl.pub")"
+check "exits 0" "0" "$(run_sync "${home_kl}" env SSH_AUTH_SOCK="${sock}")"
+check "the external literal key is preserved" "key::$(cat "${sandbox}/kl.pub" | sed 's/ *$//')" \
+  "$(git_cfg "${home_kl}" user.signingkey)"
+check "allowed_signers trusts it" "platform-literal" \
+  "$(awk 'NR==1 {print $4}' "${home_kl}/.config/git/allowed_signers")"
+
+echo
+echo "An ECDSA key is not dropped for lacking an ssh- prefix"
+home_ec="$(new_home ecdsa with-identity)"
+mkdir -p "${home_ec}/.ssh"
+ssh-keygen -q -t ecdsa -b 256 -N '' -C 'ecdsa-key' -f "${home_ec}/.ssh/ec"
+HOME="${home_ec}" git config --global user.signingkey "${home_ec}/.ssh/ec"
+check "exits 0" "0" "$(run_sync "${home_ec}" env -u SSH_AUTH_SOCK)"
+check "allowed_signers is not empty" "1" \
+  "$(wc -l <"${home_ec}/.config/git/allowed_signers" | tr -d ' ')"
+check "the ecdsa key type is preserved" "ecdsa-sha2-nistp256" \
+  "$(awk 'NR==1 {print $2}' "${home_ec}/.config/git/allowed_signers")"
+check "an ecdsa commit signs" "0" "$(try_commit "${home_ec}" ecdsa env -u SSH_AUTH_SOCK)"
+(
+  cd "${sandbox}/repo-ecdsa"
+  HOME="${home_ec}" env -u SSH_AUTH_SOCK git log -1 --show-signature
+) >"${sandbox}/verify-ec" 2>&1 || true
+grep -q "Good \"git\" signature for ${TEST_EMAIL}" "${sandbox}/verify-ec" \
+  && pass "and it verifies" \
+  || { fail "ecdsa signature did not verify"; sed 's/^/        /' "${sandbox}/verify-ec" >&2; }
 
 echo
 echo "Configuration this script does not own is left alone"


### PR DESCRIPTION
`sync-signing-key.sh` assumed the signing key always comes from a forwarded SSH agent. When a platform configures `user.signingkey` itself and no agent is forwarded, the script exited before writing `allowed_signers`, so commits signed fine but verification failed:

```
error: gpg.ssh.allowedSignersFile needs to be configured and exist for ssh signature verification
```

## Precedence

The key is now resolved from two sources:

1. **A `user.signingkey` the environment configured** — preserved exactly as-is, needs no agent.
2. **A key from a forwarded SSH agent** — the existing VS Code flow, unchanged.

The external key wins because configuring one is a deliberate act: the whole point is for it to be used, so an agent that also happens to be present must not displace it. Its public half is derived from a `*.pub` path directly, or from the `<key>.pub` beside a private key. **The private key is never read.**

Everything else is unchanged — signing stays mandatory, a missing identity or key source is reported rather than fatal, `allowed_signers` keeps the Git email as its principal, and the file is rewritten deterministically so repeated runs are idempotent.

Nothing platform-specific is added: the repo owns "make the current signing configuration locally verifiable", and whatever created the container owns "which identity and key this developer uses". An external orchestrator can invoke `.devcontainer/sync-signing-key.sh` after it has personalized Git.

## Validation

`bash .devcontainer/test-signing.sh` — 67 checks, all pass. New coverage:

- external private-key path + no agent → key preserved, `allowed_signers` written from the sibling `.pub`, **a commit signs and verifies with no agent at all**
- external `*.pub` path → used directly
- external key + agent present → external key not replaced, only it is trusted, idempotent on re-run
- external key whose public half is missing → key preserved, no bogus `allowed_signers`, signing still mandatory

Existing agent-path coverage (VS Code flow) is unchanged and still passes, and I re-ran the helper in a live VS Code devcontainer: `user.signingkey` unset, key from the agent, signed commit verifies.

`task lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Supports externally configured SSH signing keys, including private-key paths, `.pub` files, and literal public keys.
  * Local signature verification can now work without an SSH agent when the public key is available.
  * Automatically generates trusted-key verification data and reports the number of trusted keys.

* **Bug Fixes**
  * Preserves externally configured signing keys and correctly prioritizes them over agent-provided keys.

* **Documentation**
  * Updated SSH signing guidance to describe external key handling and agent-free verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->