### PR TITLE
fix(watch): stop resync storms starving other GitTargets on a branch

### DIFF
--- a/config/crd/bases/configbutler.ai_clusterproviders.yaml
+++ b/config/crd/bases/configbutler.ai_clusterproviders.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: clusterproviders.configbutler.ai
 spec:
   group: configbutler.ai

--- a/config/crd/bases/configbutler.ai_clusterwatchrules.yaml
+++ b/config/crd/bases/configbutler.ai_clusterwatchrules.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: clusterwatchrules.configbutler.ai
 spec:
   group: configbutler.ai

--- a/config/crd/bases/configbutler.ai_commitrequests.yaml
+++ b/config/crd/bases/configbutler.ai_commitrequests.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: commitrequests.configbutler.ai
 spec:
   group: configbutler.ai

--- a/config/crd/bases/configbutler.ai_gitproviders.yaml
+++ b/config/crd/bases/configbutler.ai_gitproviders.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: gitproviders.configbutler.ai
 spec:
   group: configbutler.ai

--- a/config/crd/bases/configbutler.ai_gittargets.yaml
+++ b/config/crd/bases/configbutler.ai_gittargets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: gittargets.configbutler.ai
 spec:
   group: configbutler.ai

--- a/config/crd/bases/configbutler.ai_watchrules.yaml
+++ b/config/crd/bases/configbutler.ai_watchrules.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: watchrules.configbutler.ai
 spec:
   group: configbutler.ai

--- a/internal/git/branch_worker.go
+++ b/internal/git/branch_worker.go
@@ -385,19 +385,24 @@ func (w *BranchWorker) EnqueueResync(request *ResyncRequest) bool {
 			"gitTarget", request.GitTargetNamespace+"/"+request.GitTargetName)
 		return true
 	}
+	// Insert the entry and queue its marker in ONE critical section. Releasing the
+	// lock between them would let a concurrent enqueue for the same key coalesce
+	// into an entry whose marker does not exist yet -- and which this call is
+	// about to remove on a full queue. That caller would be told enqueued=true
+	// while its request never ran and its drain waited for a reply that never
+	// came. The send is non-blocking, so holding the lock across it cannot
+	// deadlock against the loop's takePendingResync.
 	w.pendingResyncs[key] = request
-	w.pendingResyncsMu.Unlock()
-
 	w.inflightItems.Add(1)
 	select {
 	case w.eventQueue <- WorkItem{Resync: request}:
+		w.pendingResyncsMu.Unlock()
 		w.Log.V(1).Info("Resync request enqueued",
 			"resources", len(request.Desired),
 			"gitTarget", request.GitTargetNamespace+"/"+request.GitTargetName)
 		return true
 	default:
 		w.inflightItems.Add(-1)
-		w.pendingResyncsMu.Lock()
 		delete(w.pendingResyncs, key)
 		w.pendingResyncsMu.Unlock()
 		w.Log.Error(nil, "Event queue full, resync request dropped",

--- a/internal/git/branch_worker.go
+++ b/internal/git/branch_worker.go
@@ -164,6 +164,17 @@ type BranchWorker struct {
 	// handled and nothing is retained.
 	inflightItems atomic.Int64
 
+	// pendingResyncs coalesces queued resyncs by (GitTarget, scope). A resync is
+	// state-based and idempotent — "make Git match this desired set for this
+	// scope" — so a newer one wholly supersedes an older one still waiting. The
+	// map holds the current request per key; the FIFO holds one marker per key,
+	// which is what preserves ordering against live events. Queue depth is
+	// therefore bounded by the number of distinct scopes, not by the request
+	// rate, so a storm of resyncs for one target can no longer fill the queue
+	// and starve every other GitTarget on this branch.
+	pendingResyncsMu sync.Mutex
+	pendingResyncs   map[resyncKey]*ResyncRequest
+
 	// crOutcomes holds resolved CommitRequest outcomes for the controller to poll
 	// via LookupCommitRequestOutcome. The event loop is the only writer (on its
 	// goroutine), the controller the only reader (on a reconcile goroutine), so the
@@ -232,6 +243,7 @@ func NewBranchWorker(
 		),
 		contentWriter:        writer,
 		eventQueue:           make(chan WorkItem, branchWorkerQueueSize),
+		pendingResyncs:       make(map[resyncKey]*ResyncRequest),
 		branchBufferMaxBytes: branchBufferMaxBytes,
 	}
 }
@@ -353,6 +365,29 @@ func (w *BranchWorker) EnqueueResync(request *ResyncRequest) bool {
 	if request == nil {
 		return false
 	}
+	key := resyncKeyFor(request)
+
+	w.pendingResyncsMu.Lock()
+	if w.pendingResyncs == nil {
+		w.pendingResyncs = make(map[resyncKey]*ResyncRequest)
+	}
+	if superseded, queued := w.pendingResyncs[key]; queued {
+		// A marker for this key is already in the FIFO. Swap in the newer
+		// request; the loop reads whatever is current when the marker comes up.
+		w.pendingResyncs[key] = request
+		w.pendingResyncsMu.Unlock()
+		// The superseded request's caller is waiting on its reply channel. Answer
+		// it so its drain ends, with a sentinel that says "a newer resync for the
+		// same scope is queued", not "this failed".
+		superseded.reply(ResyncResult{Err: ErrResyncSuperseded})
+		w.Log.V(1).Info("Resync request coalesced into the one already queued",
+			"resources", len(request.Desired),
+			"gitTarget", request.GitTargetNamespace+"/"+request.GitTargetName)
+		return true
+	}
+	w.pendingResyncs[key] = request
+	w.pendingResyncsMu.Unlock()
+
 	w.inflightItems.Add(1)
 	select {
 	case w.eventQueue <- WorkItem{Resync: request}:
@@ -362,11 +397,31 @@ func (w *BranchWorker) EnqueueResync(request *ResyncRequest) bool {
 		return true
 	default:
 		w.inflightItems.Add(-1)
+		w.pendingResyncsMu.Lock()
+		delete(w.pendingResyncs, key)
+		w.pendingResyncsMu.Unlock()
 		w.Log.Error(nil, "Event queue full, resync request dropped",
 			"gitTarget", request.GitTargetNamespace+"/"+request.GitTargetName)
 		request.reply(ResyncResult{Err: ErrFinalizeQueueFull})
 		return false
 	}
+}
+
+// takePendingResync returns the current request for a marker's key, which may be
+// newer than the one the marker carried, and clears the key so the next enqueue
+// queues a fresh marker.
+func (w *BranchWorker) takePendingResync(marker *ResyncRequest) *ResyncRequest {
+	key := resyncKeyFor(marker)
+	w.pendingResyncsMu.Lock()
+	defer w.pendingResyncsMu.Unlock()
+	current, ok := w.pendingResyncs[key]
+	if !ok {
+		// No entry: this marker was queued before coalescing tracked it, or the
+		// key was already taken. Run what the marker carried.
+		return marker
+	}
+	delete(w.pendingResyncs, key)
+	return current
 }
 
 // enqueueRequest places a write request on the FIFO and reports whether it was
@@ -703,7 +758,11 @@ func (l *branchWorkerEventLoop) handleQueueItem(item WorkItem) {
 	}
 
 	if item.Resync != nil {
-		l.handleResyncRequest(item.Resync)
+		// Take the CURRENT request for this scope: a newer one may have replaced
+		// it while this marker waited in the FIFO. Running it here keeps the
+		// original queue position, so a resync still lands before the live events
+		// buffered behind it.
+		l.handleResyncRequest(l.w.takePendingResync(item.Resync))
 		return
 	}
 

--- a/internal/git/commit_request_attach.go
+++ b/internal/git/commit_request_attach.go
@@ -11,6 +11,13 @@ import (
 // the worker's event queue is saturated.
 var ErrFinalizeQueueFull = errors.New("branch worker event queue full; item dropped")
 
+// ErrResyncSuperseded replies to a resync that a newer request for the same
+// GitTarget and scope replaced while it was still queued. It is NOT a failure:
+// the newer request carries at least as fresh a desired set and runs in the
+// superseded one's place, so a caller must not count it as a resync that did not
+// happen.
+var ErrResyncSuperseded = errors.New("resync superseded by a newer request for the same scope")
+
 // FinalizeOutcome is the terminal result of resolving a CommitRequest.
 type FinalizeOutcome string
 

--- a/internal/git/resync_push_test.go
+++ b/internal/git/resync_push_test.go
@@ -22,12 +22,18 @@ import (
 func TestEnqueueResync_ReportsEnqueueOutcome(t *testing.T) {
 	w := &BranchWorker{Log: logr.Discard(), Branch: "main", eventQueue: make(chan WorkItem, 1)}
 
-	require.True(t, w.EnqueueResync(&ResyncRequest{Result: make(chan ResyncResult, 1)}),
-		"a resync that fits the empty queue reports enqueued=true")
+	require.True(t, w.EnqueueResync(&ResyncRequest{
+		GitTargetNamespace: "ns", GitTargetName: "first",
+		Result: make(chan ResyncResult, 1),
+	}), "a resync that fits the empty queue reports enqueued=true")
 
+	// A DIFFERENT scope, so it needs a FIFO slot of its own rather than coalescing
+	// into the queued one — which is what makes this the queue-full path.
 	dropped := make(chan ResyncResult, 1)
-	require.False(t, w.EnqueueResync(&ResyncRequest{Result: dropped}),
-		"a full queue drops the resync and reports enqueued=false")
+	require.False(t, w.EnqueueResync(&ResyncRequest{
+		GitTargetNamespace: "ns", GitTargetName: "second",
+		Result: dropped,
+	}), "a full queue drops the resync and reports enqueued=false")
 	select {
 	case res := <-dropped:
 		require.ErrorIs(t, res.Err, ErrFinalizeQueueFull,
@@ -35,6 +41,78 @@ func TestEnqueueResync_ReportsEnqueueOutcome(t *testing.T) {
 	default:
 		t.Fatal("expected a queue-full result on the dropped resync's channel")
 	}
+}
+
+// TestEnqueueResync_CoalescesSameScope pins the starvation fix. A resync is
+// state-based — "make Git match this desired set for this scope" — so a newer
+// request for the same GitTarget and scope wholly supersedes one still queued.
+// Coalescing them bounds queue depth by the number of distinct scopes instead of
+// by the request rate, so a storm of resyncs for ONE target can no longer fill a
+// branch worker's shared queue and starve every other GitTarget on that branch.
+// In the CI failure that motivated this, 595 dropped resyncs were all for a
+// single GitTarget.
+func TestEnqueueResync_CoalescesSameScope(t *testing.T) {
+	w := &BranchWorker{Log: logr.Discard(), Branch: "main", eventQueue: make(chan WorkItem, 1)}
+
+	superseded := make(chan ResyncResult, 1)
+	require.True(t, w.EnqueueResync(&ResyncRequest{
+		GitTargetNamespace: "ns", GitTargetName: "target", Revision: "1",
+		Result: superseded,
+	}))
+
+	// The queue now has no free slot, yet a second request for the SAME scope is
+	// accepted: it replaces the queued one rather than being dropped.
+	newest := make(chan ResyncResult, 1)
+	require.True(t, w.EnqueueResync(&ResyncRequest{
+		GitTargetNamespace: "ns", GitTargetName: "target", Revision: "2",
+		Result: newest,
+	}), "a resync for an already-queued scope coalesces instead of being dropped")
+
+	select {
+	case res := <-superseded:
+		require.ErrorIs(t, res.Err, ErrResyncSuperseded,
+			"the superseded caller is told a newer resync replaced it, not that it failed")
+	default:
+		t.Fatal("expected the superseded resync's channel to be answered")
+	}
+
+	// Exactly one marker is queued, and taking it yields the NEWEST request.
+	require.Len(t, w.eventQueue, 1, "coalescing must not consume a second FIFO slot")
+	item := <-w.eventQueue
+	require.NotNil(t, item.Resync)
+	current := w.takePendingResync(item.Resync)
+	assert.Equal(t, "2", current.Revision, "the marker runs the newest request for its scope")
+
+	// The key is cleared, so the next resync for that scope queues a fresh marker.
+	require.True(t, w.EnqueueResync(&ResyncRequest{
+		GitTargetNamespace: "ns", GitTargetName: "target", Revision: "3",
+		Result: make(chan ResyncResult, 1),
+	}))
+	assert.Len(t, w.eventQueue, 1, "a scope taken off the queue can be queued again")
+}
+
+// TestEnqueueResync_DistinctScopesDoNotCoalesce guards the other half: coalescing
+// must key on the scope, so two different types of the same GitTarget stay two
+// independent resyncs. Merging them would sweep one type's scope with the other
+// type's desired set, which deletes managed documents.
+func TestEnqueueResync_DistinctScopesDoNotCoalesce(t *testing.T) {
+	w := &BranchWorker{Log: logr.Discard(), Branch: "main", eventQueue: make(chan WorkItem, 4)}
+
+	configMaps := ResyncScope{GVR: schema.GroupVersionResource{Version: "v1", Resource: "configmaps"}}
+	secrets := ResyncScope{GVR: schema.GroupVersionResource{Version: "v1", Resource: "secrets"}}
+	sameTypeOtherNS := ResyncScope{
+		GVR:       schema.GroupVersionResource{Version: "v1", Resource: "configmaps"},
+		Namespace: "other",
+	}
+
+	for _, scope := range []ResyncScope{configMaps, secrets, sameTypeOtherNS} {
+		require.True(t, w.EnqueueResync(&ResyncRequest{
+			GitTargetNamespace: "ns", GitTargetName: "target",
+			Scope:  &scope,
+			Result: make(chan ResyncResult, 1),
+		}))
+	}
+	assert.Len(t, w.eventQueue, 3, "each distinct scope holds its own FIFO slot")
 }
 
 // TestHandleResyncRequest_ClosedWindowIsPushedEvenWhenNoOpResync pins the

--- a/internal/git/resync_push_test.go
+++ b/internal/git/resync_push_test.go
@@ -3,6 +3,8 @@
 package git
 
 import (
+	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -89,6 +91,78 @@ func TestEnqueueResync_CoalescesSameScope(t *testing.T) {
 		Result: make(chan ResyncResult, 1),
 	}))
 	assert.Len(t, w.eventQueue, 1, "a scope taken off the queue can be queued again")
+}
+
+// TestEnqueueResync_AcceptedRequestAlwaysRuns pins the atomicity of insert-and-queue
+// under a full queue. The invariant: a request told enqueued=true must either have
+// the FIFO marker for its scope, or have been superseded by a later one. Anything
+// else is a caller that believes its resync is queued -- and so advances the
+// per-type coverage watermark -- for work that will never run, while its drain
+// waits for a reply that never comes.
+//
+// The failure needed the entry to be visible to a concurrent enqueue before its
+// marker existed, so this drives the window concurrently and repeatedly rather
+// than asserting a single interleaving.
+func TestEnqueueResync_AcceptedRequestAlwaysRuns(t *testing.T) {
+	for range 200 {
+		acceptedCount, supersededCount, markers := raceEnqueuesOnOneScope(t)
+		require.Equal(t, acceptedCount, supersededCount+markers,
+			"every accepted resync must own the marker or have been superseded")
+	}
+}
+
+// raceEnqueuesOnOneScope drives concurrent enqueues for a single scope against a
+// full queue, and reports how many were accepted, how many of those were
+// superseded, and whether a marker survives for the scope.
+func raceEnqueuesOnOneScope(t *testing.T) (int, int, int) {
+	t.Helper()
+	const enqueuers = 8
+
+	w := &BranchWorker{Log: logr.Discard(), Branch: "main", eventQueue: make(chan WorkItem, 1)}
+	// Occupy the only slot with an unrelated scope, so every request below races
+	// on the same key against a full queue.
+	require.True(t, w.EnqueueResync(&ResyncRequest{
+		GitTargetNamespace: "ns", GitTargetName: "filler",
+		Result: make(chan ResyncResult, 1),
+	}))
+
+	acceptedCount, supersededCount, markers := 0, 0, 0
+	results := make([]chan ResyncResult, enqueuers)
+	accepted := make([]bool, enqueuers)
+	var wg sync.WaitGroup
+	for i := range enqueuers {
+		results[i] = make(chan ResyncResult, 1)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			accepted[i] = w.EnqueueResync(&ResyncRequest{
+				GitTargetNamespace: "ns", GitTargetName: "contended",
+				Result: results[i],
+			})
+		}()
+	}
+	wg.Wait()
+
+	for len(w.eventQueue) > 0 {
+		if item := <-w.eventQueue; item.Resync != nil && item.Resync.GitTargetName == "contended" {
+			markers++
+		}
+	}
+
+	for i := range enqueuers {
+		if !accepted[i] {
+			continue
+		}
+		acceptedCount++
+		select {
+		case res := <-results[i]:
+			if errors.Is(res.Err, ErrResyncSuperseded) {
+				supersededCount++
+			}
+		default:
+		}
+	}
+	return acceptedCount, supersededCount, markers
 }
 
 // TestEnqueueResync_DistinctScopesDoNotCoalesce guards the other half: coalescing

--- a/internal/git/types.go
+++ b/internal/git/types.go
@@ -407,6 +407,24 @@ type ResyncRequest struct {
 	Result chan ResyncResult
 }
 
+// resyncKey identifies the slice of a mirror a resync reconciles: one GitTarget,
+// and the scope within it. Two requests sharing a key are interchangeable in the
+// sense that matters — the newer one's desired set wholly supersedes the older's —
+// which is what makes coalescing them safe.
+type resyncKey struct {
+	namespace string
+	name      string
+	scope     string
+}
+
+func resyncKeyFor(request *ResyncRequest) resyncKey {
+	key := resyncKey{namespace: request.GitTargetNamespace, name: request.GitTargetName}
+	if request.Scope != nil {
+		key.scope = request.Scope.GVR.String() + "|" + request.Scope.Namespace
+	}
+	return key
+}
+
 // ResyncResult is the reply to a ResyncRequest: the plan's change counts, or an
 // error if the resync could not be applied (in which case nothing was committed).
 type ResyncResult struct {

--- a/internal/watch/event_router.go
+++ b/internal/watch/event_router.go
@@ -6,13 +6,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	configv1alpha3 "github.com/ConfigButler/gitops-reverser/api/v1alpha3"

--- a/internal/watch/event_router.go
+++ b/internal/watch/event_router.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sync"
 	"time"
 
@@ -147,6 +148,13 @@ func (r *EventRouter) recordBackgroundResyncFailure(gitDest types.ResourceRefere
 	))
 }
 
+// errGitTargetGone reports that a GitTarget no longer exists. It is terminal:
+// nothing that depends on the target can succeed again, so a supervisor loop must
+// stop rather than reconnect. Retrying instead is what let a deleted GitTarget's
+// streams re-enqueue resyncs every backoff, filling the branch worker's shared
+// queue and starving every other GitTarget on the same branch.
+var errGitTargetGone = errors.New("GitTarget no longer exists")
+
 // resolveWorkerForGitDest looks up the branch worker that owns a GitTarget's provider/branch.
 // A missing GitTarget (a rule briefly outliving its target during deletion) or a worker that
 // is not yet live is returned as an error, before anything is gathered or enqueued.
@@ -159,6 +167,12 @@ func (r *EventRouter) resolveWorkerForGitDest(
 		Name:      gitDest.Name,
 		Namespace: gitDest.Namespace,
 	}, &gitTarget); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Distinguished from any other lookup failure because it is terminal:
+			// the target is gone, so a caller retrying this forever is doing work
+			// that can never succeed. See errGitTargetGone.
+			return nil, fmt.Errorf("%w: %s", errGitTargetGone, gitDest.String())
+		}
 		return nil, fmt.Errorf("get GitTarget %s: %w", gitDest.String(), err)
 	}
 	worker, exists := r.WorkerManager.GetWorkerForTarget(
@@ -281,6 +295,13 @@ func (r *EventRouter) handleScopedResyncError(
 		if r.WatchManager != nil {
 			r.WatchManager.MarkTargetGitPathRefused(gitDest, gitPathRefusalReason(refused), refused.BlockMessage())
 		}
+		return
+	}
+	if errors.Is(err, git.ErrResyncSuperseded) {
+		// A newer resync for the same scope replaced this one while it was queued
+		// and runs in its place, so nothing was missed and nothing failed.
+		r.Log.V(1).Info("per-type "+kind+" superseded by a newer resync",
+			"gitDest", gitDest.String(), "gvr", key.GVR.String())
 		return
 	}
 	r.Log.Error(err, "per-type "+kind+" failed", "gitDest", gitDest.String(), "gvr", key.GVR.String())

--- a/internal/watch/event_router_test.go
+++ b/internal/watch/event_router_test.go
@@ -156,7 +156,7 @@ func TestDrainScopedResync_TreatsSupersededAsSuccess(t *testing.T) {
 		router.drainScopedResync(
 			types.NewResourceReference("team-a-config", "team-a"),
 			targetWatchKey{GVR: configmapsGVR},
-			"reconcile",
+			"sweep",
 			0,
 			resultCh,
 		)

--- a/internal/watch/event_router_test.go
+++ b/internal/watch/event_router_test.go
@@ -110,6 +110,65 @@ func TestEnqueueScopedResync_ReportsMissingWorker(t *testing.T) {
 	assert.Contains(t, err.Error(), "no worker")
 }
 
+// TestEnqueueScopedResync_ReportsGoneGitTargetAsTerminal pins the storm fix. A
+// GitTarget that no longer exists is terminal, not a transient lookup failure:
+// the target-watch supervisor stops on errGitTargetGone instead of reconnecting
+// every backoff. Retrying instead is what let a deleted GitTarget's streams
+// re-enqueue resyncs forever, filling the branch worker's shared queue and
+// starving every other GitTarget on the branch.
+func TestEnqueueScopedResync_ReportsGoneGitTargetAsTerminal(t *testing.T) {
+	scheme := eventRouterScheme(t)
+	client := fake.NewClientBuilder().WithScheme(scheme).Build() // no GitTarget exists
+	workerManager := git.NewWorkerManager(client, logr.Discard(), 0, types.SensitiveResourcePolicy{})
+	router := NewEventRouter(workerManager, nil, client, logr.Discard())
+
+	_, enqueued, err := router.enqueueScopedResync(
+		context.Background(),
+		types.NewResourceReference("deleted-target", "team-a"),
+		git.ResyncScope{GVR: configmapsGVR},
+		nil,
+		"12",
+		false,
+	)
+
+	require.Error(t, err)
+	assert.False(t, enqueued)
+	assert.ErrorIs(t, err, errGitTargetGone,
+		"a missing GitTarget is distinguishable so its supervisor can stop rather than retry")
+}
+
+// TestDrainScopedResync_TreatsSupersededAsSuccess guards the coalescing contract
+// from the other side: a resync replaced by a newer one for the same scope did
+// not fail — the newer one runs in its place — so it must not be counted as a
+// background resync failure or logged as an error.
+func TestDrainScopedResync_TreatsSupersededAsSuccess(t *testing.T) {
+	scheme := eventRouterScheme(t)
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+	workerManager := git.NewWorkerManager(client, logr.Discard(), 0, types.SensitiveResourcePolicy{})
+	router := NewEventRouter(workerManager, nil, client, logr.Discard())
+
+	resultCh := make(chan git.ResyncResult, 1)
+	resultCh <- git.ResyncResult{Err: git.ErrResyncSuperseded}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		router.drainScopedResync(
+			types.NewResourceReference("team-a-config", "team-a"),
+			targetWatchKey{GVR: configmapsGVR},
+			"reconcile",
+			0,
+			resultCh,
+		)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("drain did not complete for a superseded resync")
+	}
+}
+
 func TestDrainScopedResync_CompletesSuccessfulResult(t *testing.T) {
 	scheme := eventRouterScheme(t)
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()

--- a/internal/watch/target_watch.go
+++ b/internal/watch/target_watch.go
@@ -318,6 +318,15 @@ func (m *Manager) runTargetWatch(
 		if ctx.Err() != nil {
 			return
 		}
+		if errors.Is(err, errGitTargetGone) {
+			// Terminal: reconnecting would replay and re-enqueue a resync for a
+			// GitTarget that no longer exists, every backoff, forever. The
+			// declaration teardown removes this stream; stopping now just means
+			// not burning the branch worker's shared queue until it does.
+			log.Info("target watch stopping; its GitTarget is gone",
+				"gitDest", gitDest.String(), "gvr", key.GVR.String(), "namespace", key.Namespace)
+			return
+		}
 		if err != nil {
 			m.markTargetStreamState(gitDest, key, StreamStateBlocked, StreamReasonWatchError, err.Error())
 			log.Info("target watch session ended; reconnecting",


### PR DESCRIPTION
Fixes the e2e flake that has been costing a retry on roughly a third of `main` runs.

## What was actually happening

A branch worker's event queue is a **100-slot FIFO shared by every GitTarget on one provider and branch**. In run [32848418546](https://github.com/ConfigButler/gitops-reverser/actions/runs/32848418546) it filled and dropped 595 resync requests in 16 seconds — and all 595 were for a **single** GitTarget whose namespace was being deleted:

```
total dropped resyncs: 595
distinct GitTargets   : 1
    595  …test-manager-unsupported-folder/unsupported-folder-dest
```

Unrelated specs then timed out at 90s waiting for a WatchRule to report `Ready`, because the resync that would have advanced it never entered the queue. The stuck WatchRule reconciled every 10s and reported success each time — it was waiting on an axis condition a dropped resync should have moved.

Five different specs failed this way across three attempts, which is exactly why it looked like random flakiness rather than one bug.

## The two changes

**1. A deleted GitTarget is terminal for its target watches.** Its lookup failure is now reported as `errGitTargetGone` rather than a generic error, and the supervisor loop stops instead of reconnecting after every 2s backoff. It was previously replaying and re-enqueuing a resync forever, per stream, for a target that could never come back. This removes the storm at its source.

**2. Queued resyncs coalesce by `(GitTarget, scope)`.** A resync is state-based and idempotent — "make Git match this desired set for this scope" — so a newer request wholly supersedes one still waiting. The FIFO holds one marker per scope; the map holds the current request. The marker keeps its **original queue position**, so a resync still lands before the live events buffered behind it, while running the **newest** desired set.

Queue depth is now bounded by the number of distinct scopes instead of by the request rate, so no storm can fill it. 595 requests for one target collapse to one.

## Correctness notes

- A superseded request is answered with `ErrResyncSuperseded`, which the drain treats as **neither a failure nor a missed reconcile** — the newer request runs in its place with at least as fresh a snapshot. It is not counted in `ResyncBackgroundFailuresTotal`.
- **Scope is part of the coalescing key.** Two types of one GitTarget stay independent; merging them would sweep one type's scope with another type's desired set, which deletes managed documents.
- The queue-full drop contract still holds for *distinct* scopes, so the per-type coverage watermark still never advances for a reconcile that did not queue. `TestEnqueueResync_ReportsEnqueueOutcome` was updated to use two different targets, since two requests for the same scope now legitimately coalesce rather than drop.

## Validation

- `task lint` — pass
- `task test` — pass, coverage 76.7% unchanged
- New tests: coalescing on a full queue, distinct scopes not coalescing, the marker running the newest request, a taken scope re-queueing, `errGitTargetGone` being distinguishable, and the drain treating superseded as success

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Coalesced duplicate resync requests for the same target and scope, reducing redundant processing.
  * Replaced superseded requests cleanly while preserving queue order and allowing future requests.
  * Prevented repeated retries when a monitored Git target has been deleted.
  * Treated superseded resyncs as successful completion instead of failures.
  * Improved handling when resync queues reach capacity.

* **Chores**
  * Updated generated resource metadata to reflect the latest generation tooling version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->