### PR TITLE
ci: require pull request titles to be Conventional Commits

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,49 @@
+# PR titles become the squash-merge commit subject (the repository squash-merges with
+# COMMIT_OR_PR_TITLE), and release-please reads those subjects to decide the version bump and
+# to write the changelog. A title that is not a Conventional Commit is therefore not a style
+# nit: it is a change that release-please cannot classify. This check fails such a PR until the
+# title is fixed, and re-runs on `edited` so fixing the title is enough to turn it green.
+#
+# Deliberately a plain shell check rather than a marketplace action: there is no secret, no
+# write, and nothing to pin. The title is passed through an environment variable, never
+# interpolated into the script, so a hostile title cannot become shell.
+name: PR title
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  conventional-commit:
+    name: Conventional Commit title
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check the title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          # The type list is the one release-please-config.json classifies, so a title that
+          # passes here is one the changelog can file. Scope is optional; `!` marks a breaking
+          # change; the subject must follow ": " and must not be empty.
+          pattern='^(feat|fix|perf|revert|docs|style|chore|refactor|test|build|ci)(\([A-Za-z0-9._/ -]+\))?!?: [^ ].*$'
+          if [[ "$PR_TITLE" =~ $pattern ]]; then
+            echo "ok: $PR_TITLE"
+            exit 0
+          fi
+          {
+            echo "## PR title is not a Conventional Commit"
+            echo
+            echo '```'
+            echo "$PR_TITLE"
+            echo '```'
+            echo
+            echo 'Expected `type(scope): imperative summary`, scope optional, `!` before the colon for a'
+            echo 'breaking change. Types: feat, fix, perf, revert, docs, style, chore, refactor, test,'
+            echo 'build, ci. Examples: `feat(controller): add SSH key rotation`,'
+            echo '`fix(webhook)!: reject unsigned requests`. Edit the title and this check re-runs.'
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+          exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -208,6 +208,11 @@ determines whether a release is triggered and what version bump applies:
 
 Examples: `feat(controller): add SSH key rotation`, `fix(webhook): prevent queue race`
 
+The pull request **title** must follow the same format: the repository squash-merges with the PR
+title as the commit subject, so that title is what release-please classifies. The
+[`PR title`](.github/workflows/pr-title.yml) check fails a PR whose title does not parse, and
+re-runs when the title is edited.
+
 See [`.github/RELEASES.md`](.github/RELEASES.md) for how releases and changelogs are automated.
 
 ## AI tooling

--- a/docs/ci-overview.md
+++ b/docs/ci-overview.md
@@ -18,6 +18,7 @@ so local and CI results cannot drift apart.
 | Trusted validation | [release.yml](../.github/workflows/release.yml) → calls `ci.yml` | `push` to `main` | `GITHUB_TOKEN` | `packages` (CI base container + release-grade image digests) | The *same* jobs, plus building the release-grade multi-arch digests (per-arch, by digest) the release tail retags. The instrumented test image stays artifact-only. |
 | Release & publish | [release.yml](../.github/workflows/release.yml) tail jobs | after trusted validation is green | `GITHUB_TOKEN` + OIDC | packages, releases, attestations | Version (release-please), **retag** the CI-built multi-arch digests to semver + `latest` (zero rebuilds), publish chart, sign, attest |
 | Hygiene | [scorecard.yml](../.github/workflows/scorecard.yml) | weekly + `main` | none | security-events | OpenSSF Scorecard supply-chain checks |
+| Hygiene | [pr-title.yml](../.github/workflows/pr-title.yml) | `pull_request` (including `edited`) | none | none | The PR title is a Conventional Commit, since it becomes the squash-merge subject release-please classifies |
 
 Three properties are worth calling out:
 


### PR DESCRIPTION
## Summary

- Adds a `PR title` workflow that fails a pull request whose title is not a Conventional Commit, and re-runs on `edited` so fixing the title is enough to turn it green.
- The type list is the one `release-please-config.json` classifies. Scope is optional, `!` marks a breaking change, the subject must be non-empty. release-please's `chore(main): release x.y.z` and dependabot's `chore(deps): bump ...` titles pass.
- Plain shell, no marketplace action: nothing to pin, no write permission, and the title reaches the script through an environment variable rather than interpolation.
- Documents the rule in `CONTRIBUTING.md` and lists the workflow in `docs/ci-overview.md`.

Why the title and not the commits: the repository squash-merges with `COMMIT_OR_PR_TITLE`, so the PR title is the subject release-please reads for the bump and the changelog.

**After merge:** add `Conventional Commit title` to the main ruleset's required checks (GitHub only lists a check name once it has run).

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated validation to ensure pull request titles follow the Conventional Commits format.
  * Validation runs when pull requests are opened, edited, reopened, synchronized, or marked ready for review.

* **Documentation**
  * Updated contribution and CI documentation with pull request title requirements and validation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->