### PR TITLE
refactor(status): let the status session stamp observedGeneration

### DIFF
--- a/api/v1alpha3/status_accessors.go
+++ b/api/v1alpha3/status_accessors.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha3
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// The kstatus status bookkeeping, reachable without knowing which kind you hold.
+//
+// Every status in this package carries the same two fields — the generation the controller
+// observed, and the condition set — and the controllers' shared status session needs both: it
+// stamps the generation as the session opens, and rewrites the conditions as gates report. Written
+// out per kind, the stamp was five identical lines that a sixth kind could simply forget, and
+// forgetting it publishes a status kstatus reads as CURRENT for a spec nobody looked at. These
+// accessors let the session do it once. See internal/controller's statusObject, which is the
+// interface these satisfy.
+//
+// CommitRequest is deliberately not here: it does not use that helper (see the comment on
+// requeueAfter for why), so an accessor on it would be a method nothing calls.
+
+// SetObservedGeneration records the generation this object's status describes.
+func (t *GitTarget) SetObservedGeneration(generation int64) { t.Status.ObservedGeneration = generation }
+
+// StatusConditions returns the condition set to write through.
+func (t *GitTarget) StatusConditions() *[]metav1.Condition { return &t.Status.Conditions }
+
+// SetObservedGeneration records the generation this object's status describes.
+func (p *GitProvider) SetObservedGeneration(generation int64) {
+	p.Status.ObservedGeneration = generation
+}
+
+// StatusConditions returns the condition set to write through.
+func (p *GitProvider) StatusConditions() *[]metav1.Condition { return &p.Status.Conditions }
+
+// SetObservedGeneration records the generation this object's status describes.
+func (p *ClusterProvider) SetObservedGeneration(generation int64) {
+	p.Status.ObservedGeneration = generation
+}
+
+// StatusConditions returns the condition set to write through.
+func (p *ClusterProvider) StatusConditions() *[]metav1.Condition { return &p.Status.Conditions }
+
+// SetObservedGeneration records the generation this object's status describes.
+func (r *WatchRule) SetObservedGeneration(generation int64) { r.Status.ObservedGeneration = generation }
+
+// StatusConditions returns the condition set to write through.
+func (r *WatchRule) StatusConditions() *[]metav1.Condition { return &r.Status.Conditions }
+
+// SetObservedGeneration records the generation this object's status describes.
+func (r *ClusterWatchRule) SetObservedGeneration(generation int64) {
+	r.Status.ObservedGeneration = generation
+}
+
+// StatusConditions returns the condition set to write through.
+func (r *ClusterWatchRule) StatusConditions() *[]metav1.Condition { return &r.Status.Conditions }

--- a/api/v1alpha3/status_accessors_test.go
+++ b/api/v1alpha3/status_accessors_test.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha3
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// statusAccessors restates, inside this package, the two methods internal/controller's status
+// session reaches an object through. A kind listed below that is missing an accessor fails to
+// compile HERE, next to the types, rather than at whichever controller happened to use it.
+type statusAccessors interface {
+	SetObservedGeneration(generation int64)
+	StatusConditions() *[]metav1.Condition
+}
+
+// TestStatusAccessors_ReachTheLiveStatus covers every kind whose controller opens a status session.
+// Both accessors must reach the object's OWN status: a SetObservedGeneration that wrote nowhere, or
+// a StatusConditions handing back a copy, would leave the controllers publishing an empty status
+// while nothing about the call sites looked wrong.
+func TestStatusAccessors_ReachTheLiveStatus(t *testing.T) {
+	t.Parallel()
+
+	gitTarget := &GitTarget{}
+	gitProvider := &GitProvider{}
+	clusterProvider := &ClusterProvider{}
+	watchRule := &WatchRule{}
+	clusterWatchRule := &ClusterWatchRule{}
+
+	tests := []struct {
+		name     string
+		object   statusAccessors
+		observed func() int64
+		stored   func() []metav1.Condition
+	}{
+		{
+			name: "GitTarget", object: gitTarget,
+			observed: func() int64 { return gitTarget.Status.ObservedGeneration },
+			stored:   func() []metav1.Condition { return gitTarget.Status.Conditions },
+		},
+		{
+			name: "GitProvider", object: gitProvider,
+			observed: func() int64 { return gitProvider.Status.ObservedGeneration },
+			stored:   func() []metav1.Condition { return gitProvider.Status.Conditions },
+		},
+		{
+			name: "ClusterProvider", object: clusterProvider,
+			observed: func() int64 { return clusterProvider.Status.ObservedGeneration },
+			stored:   func() []metav1.Condition { return clusterProvider.Status.Conditions },
+		},
+		{
+			name: "WatchRule", object: watchRule,
+			observed: func() int64 { return watchRule.Status.ObservedGeneration },
+			stored:   func() []metav1.Condition { return watchRule.Status.Conditions },
+		},
+		{
+			name: "ClusterWatchRule", object: clusterWatchRule,
+			observed: func() int64 { return clusterWatchRule.Status.ObservedGeneration },
+			stored:   func() []metav1.Condition { return clusterWatchRule.Status.Conditions },
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tc.object.SetObservedGeneration(9)
+			assert.Equal(t, int64(9), tc.observed())
+
+			*tc.object.StatusConditions() = append(*tc.object.StatusConditions(),
+				metav1.Condition{Type: "Ready", Status: metav1.ConditionTrue, Reason: "Succeeded"})
+			require.Len(t, tc.stored(), 1, "StatusConditions must point at the object's own slice")
+		})
+	}
+}

--- a/internal/controller/clusterprovider_controller.go
+++ b/internal/controller/clusterprovider_controller.go
@@ -165,8 +165,7 @@ func (r *ClusterProviderReconciler) reconcileClusterProvider(
 		"inCluster", provider.IsInCluster(),
 		"generation", provider.Generation)
 
-	st := beginStatus(r.Client, r.Recorder, provider, &provider.Status.Conditions)
-	provider.Status.ObservedGeneration = provider.Generation
+	st := beginStatus(r.Client, r.Recorder, provider)
 
 	valid, reason, message, err := r.validateProviderKubeConfig(ctx, provider)
 	if err != nil {

--- a/internal/controller/clusterprovider_controller_unit_test.go
+++ b/internal/controller/clusterprovider_controller_unit_test.go
@@ -326,7 +326,7 @@ func TestReconcileStatusCommit_DeletedObject(t *testing.T) {
 		WithStatusSubresource(&configbutleraiv1alpha3.ClusterProvider{}).
 		Build()
 	provider := clusterProviderWithKubeConfig("gone", "", "")
-	st := beginStatus(cl, nil, provider, &provider.Status.Conditions)
+	st := beginStatus(cl, nil, provider)
 	st.set(ConditionTypeReady, metav1.ConditionTrue, ReasonSucceeded, "gone but written")
 
 	// The object was never created, so the patch returns NotFound -> treated as done, no error.

--- a/internal/controller/clusterwatchrule_controller.go
+++ b/internal/controller/clusterwatchrule_controller.go
@@ -112,8 +112,7 @@ func (r *ClusterWatchRuleReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		"target", clusterRule.Spec.GitTargetRef,
 		"generation", clusterRule.Generation,
 		"resourceVersion", clusterRule.ResourceVersion)
-	st := beginStatus(r.Client, r.Recorder, &clusterRule, &clusterRule.Status.Conditions)
-	clusterRule.Status.ObservedGeneration = clusterRule.Generation
+	st := beginStatus(r.Client, r.Recorder, &clusterRule)
 
 	// Seed the axis conditions as not-yet-evaluated. There is deliberately no placeholder write of
 	// the Ready/Reconciling/Stalled trio here: every path below ends in exactly one applyReadiness.

--- a/internal/controller/gitprovider_controller.go
+++ b/internal/controller/gitprovider_controller.go
@@ -100,8 +100,7 @@ func (r *GitProviderReconciler) reconcileGitProvider(
 		"generation", gitProvider.Generation,
 		"resourceVersion", gitProvider.ResourceVersion)
 
-	st := beginStatus(r.Client, r.Recorder, gitProvider, &gitProvider.Status.Conditions)
-	gitProvider.Status.ObservedGeneration = gitProvider.Generation
+	st := beginStatus(r.Client, r.Recorder, gitProvider)
 	rd := newReadiness(
 		fmt.Sprintf("Repository connectivity validated for %s", gitProvider.Spec.URL),
 		"GitProvider is not stalled",

--- a/internal/controller/gitprovider_controller_test.go
+++ b/internal/controller/gitprovider_controller_test.go
@@ -220,7 +220,7 @@ var _ = Describe("GitProvider Controller", func() {
 					Conditions: []metav1.Condition{},
 				},
 			}
-			st = beginStatus(k8sClient, nil, gitProvider, &gitProvider.Status.Conditions)
+			st = beginStatus(k8sClient, nil, gitProvider)
 		})
 
 		It("should set initial checking condition", func() {

--- a/internal/controller/gittarget_controller.go
+++ b/internal/controller/gittarget_controller.go
@@ -164,8 +164,7 @@ func (r *GitTargetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return r.handleFetchError(err, log, req.NamespacedName)
 	}
 
-	st := beginStatus(r.Client, r.Recorder, &target, &target.Status.Conditions)
-	target.Status.ObservedGeneration = target.Generation
+	st := beginStatus(r.Client, r.Recorder, &target)
 	gitPathWasRefused := conditionIsFalse(target.Status.Conditions, GitTargetConditionGitPathAccepted)
 
 	// Ahead of every gate, so a target held unready still shows what its folder resolved to. That

--- a/internal/controller/gittarget_layout_test.go
+++ b/internal/controller/gittarget_layout_test.go
@@ -28,7 +28,7 @@ func layoutTestTarget() *configbutleraiv1alpha3.GitTarget {
 func publishForTest(t *testing.T, report git.LayoutReport, scanned bool) *configbutleraiv1alpha3.GitTarget {
 	t.Helper()
 	target := layoutTestTarget()
-	st := beginStatus(nil, nil, target, &target.Status.Conditions)
+	st := beginStatus(nil, nil, target)
 	publishLayout(st, target, report, scanned)
 	return target
 }

--- a/internal/controller/gittarget_placement_validation_test.go
+++ b/internal/controller/gittarget_placement_validation_test.go
@@ -183,7 +183,7 @@ func TestEvaluateValidatedGate_InvalidPlacementPolicy(t *testing.T) {
 
 	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(provider, target).Build()
 	reconciler := &GitTargetReconciler{Client: client}
-	st := beginStatus(client, nil, target, &target.Status.Conditions)
+	st := beginStatus(client, nil, target)
 
 	validated, msg, err := reconciler.evaluateValidatedGate(context.Background(), st, target, ns)
 

--- a/internal/controller/gittarget_status_test.go
+++ b/internal/controller/gittarget_status_test.go
@@ -150,7 +150,7 @@ func TestGitTargetReadinessGates(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			target := &configbutleraiv1alpha3.GitTarget{}
-			st := beginStatus(nil, nil, target, &target.Status.Conditions)
+			st := beginStatus(nil, nil, target)
 			observed := dataPlaneObservation{
 				streams: tt.streams,
 				axes: gitTargetAxes{
@@ -194,7 +194,7 @@ func unstructuredConditions(conditions []metav1.Condition) []map[string]interfac
 // data plane is ever evaluated.
 func TestGitTargetStall_PublishesTerminalTrio(t *testing.T) {
 	target := &configbutleraiv1alpha3.GitTarget{}
-	st := beginStatus(nil, nil, target, &target.Status.Conditions)
+	st := beginStatus(nil, nil, target)
 
 	rd := newGitTargetReadiness()
 	rd.stalled(GitTargetReadyReasonValidationFailed, "Validated gate failed: ProviderNotFound")
@@ -266,7 +266,7 @@ func TestStatusCommit_LostRaceIsRecordedSoTheCallerComesBack(t *testing.T) {
 			},
 		}).Build()
 
-	st := beginStatus(conflicting, nil, target, &target.Status.Conditions)
+	st := beginStatus(conflicting, nil, target)
 	st.set(GitTargetConditionReady, metav1.ConditionTrue, ReasonSucceeded, "converged")
 
 	require.NoError(t, st.commit(context.Background()),
@@ -307,7 +307,7 @@ func TestStall_LostWriteComesBackPromptly(t *testing.T) {
 		}).Build()
 
 	reconciler := &GitTargetReconciler{Client: conflicting}
-	st := beginStatus(conflicting, nil, target, &target.Status.Conditions)
+	st := beginStatus(conflicting, nil, target)
 
 	result, err := reconciler.stall(context.Background(), st, blockedGate{
 		reason:  GitTargetReadyReasonValidationFailed,
@@ -332,7 +332,7 @@ func TestStall_KeepsItsGateCadenceWhenTheWriteLands(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(target).WithStatusSubresource(target).Build()
 
 	reconciler := &GitTargetReconciler{Client: c}
-	st := beginStatus(c, nil, target, &target.Status.Conditions)
+	st := beginStatus(c, nil, target)
 
 	result, err := reconciler.stall(context.Background(), st, blockedGate{
 		reason:  GitTargetReadyReasonValidationFailed,
@@ -355,7 +355,7 @@ func TestStatusCommit_SuccessfulWriteIsNotFlaggedAsLost(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(target).
 		WithStatusSubresource(target).Build()
 
-	st := beginStatus(c, nil, target, &target.Status.Conditions)
+	st := beginStatus(c, nil, target)
 	st.set(GitTargetConditionReady, metav1.ConditionTrue, ReasonSucceeded, "converged")
 
 	require.NoError(t, st.commit(context.Background()))

--- a/internal/controller/resource_condition_metrics.go
+++ b/internal/controller/resource_condition_metrics.go
@@ -37,6 +37,12 @@ const (
 // conditionMetricKind names the kind an object publishes under, or "" for one that is not on the
 // surface. The type switch is the surface: a kind that is not listed cannot reach the metric, so
 // the exclusion above is structural rather than a rule someone has to remember.
+//
+// Which is why the kind does NOT come off statusObject, the accessor interface the status session
+// takes. That interface is about writing a status, and anything can be given the two methods it
+// asks for; hanging the kind on it would turn this list into an implication — implement the
+// accessors over in api/v1alpha3 and you are on the metric — and CommitRequest would arrive here by
+// a route nobody reviewing that file would see.
 func conditionMetricKind(obj client.Object) string {
 	switch obj.(type) {
 	case *configbutleraiv1alpha3.GitTarget:

--- a/internal/controller/resource_condition_metrics_test.go
+++ b/internal/controller/resource_condition_metrics_test.go
@@ -57,7 +57,7 @@ func TestPublishConditionMetrics_PublishesWhenTheStatusPatchIsANoOp(t *testing.T
 
 	// A nil client is safe precisely because this reconcile writes nothing: if commit() ever got as
 	// far as the patch, this test would panic rather than pass for the wrong reason.
-	st := beginStatus(nil, nil, target, &target.Status.Conditions)
+	st := beginStatus(nil, nil, target)
 	require.NoError(t, st.commit(context.Background()))
 
 	value, ok := conditionGaugeValue(t, reader, conditionKindGitTarget, "settled", ConditionTypeReady, "True")
@@ -76,7 +76,7 @@ func TestPublishConditionMetrics_SynthesizesUnknown(t *testing.T) {
 	rule := &configbutleraiv1alpha3.WatchRule{
 		ObjectMeta: metav1.ObjectMeta{Name: "fresh", Namespace: conditionTestNamespace, ResourceVersion: "1"},
 	}
-	st := beginStatus(nil, nil, rule, &rule.Status.Conditions)
+	st := beginStatus(nil, nil, rule)
 	require.NoError(t, st.commit(context.Background()))
 
 	for _, conditionType := range []string{ConditionTypeReady, ConditionTypeReconciling, ConditionTypeStalled} {
@@ -102,14 +102,14 @@ func TestPublishConditionMetrics_ForgetsAnObjectThatIsGoing(t *testing.T) {
 			},
 		},
 	}
-	st := beginStatus(nil, nil, target, &target.Status.Conditions)
+	st := beginStatus(nil, nil, target)
 	require.NoError(t, st.commit(context.Background()))
 	_, ok := conditionGaugeValue(t, reader, conditionKindGitTarget, "doomed", ConditionTypeReady, "True")
 	require.True(t, ok)
 
 	deleting := metav1.Now()
 	target.DeletionTimestamp = &deleting
-	st = beginStatus(nil, nil, target, &target.Status.Conditions)
+	st = beginStatus(nil, nil, target)
 	require.NoError(t, st.commit(context.Background()))
 
 	_, ok = conditionGaugeValue(t, reader, conditionKindGitTarget, "doomed", ConditionTypeReady, "True")

--- a/internal/controller/ssh_test.go
+++ b/internal/controller/ssh_test.go
@@ -425,7 +425,7 @@ func TestGitProviderConditions(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.reason, func(t *testing.T) {
-			st := beginStatus(nil, nil, gitProvider, &gitProvider.Status.Conditions)
+			st := beginStatus(nil, nil, gitProvider)
 			st.set(ConditionTypeReady, tc.status, tc.reason, tc.message)
 
 			if len(gitProvider.Status.Conditions) == 0 {

--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -106,15 +106,38 @@ func (s *reconcileStatus) requeueAfter(cadence time.Duration) time.Duration {
 	return cadence
 }
 
+// statusObject is what a status session needs from the object it writes: the two fields every
+// status in api/v1alpha3 carries, reachable without knowing which kind is in hand.
+//
+// It exists so beginStatus can stamp observedGeneration itself. That line used to sit at each of
+// the five call sites, one identical copy per controller, and a controller that forgets it
+// publishes a status kstatus reads as Current for a spec nobody looked at — the same failure the
+// read-modify-write pattern above had. Reaching the conditions through the object rather than
+// beside it falls out of the same accessor, and removes the second way to get a session wrong:
+// handing it one object's conditions and another object's metadata.
+//
+// It carries no kind name, on purpose. conditionMetricKind resolves that from its own list,
+// because CommitRequest is excluded from the condition metric and an interface anything could
+// implement is not a place to keep an exclusion. See resource_condition_metrics.go.
+type statusObject interface {
+	client.Object
+
+	// SetObservedGeneration records the generation this object's status describes.
+	SetObservedGeneration(generation int64)
+	// StatusConditions returns the condition set to write through.
+	StatusConditions() *[]metav1.Condition
+}
+
 // beginStatus opens the status session. Call it once, immediately after the object is read and
 // before any condition is written.
-func beginStatus(
-	c client.Client,
-	recorder record.EventRecorder,
-	object client.Object,
-	conditions *[]metav1.Condition,
-) *reconcileStatus {
+//
+// The generation is stamped here, AFTER before is captured and ahead of every set(): capturing the
+// snapshot first is what leaves the stamp visible to the patch, so an object whose only status
+// change is a new observedGeneration still gets written rather than falling into commit()'s no-op.
+func beginStatus(c client.Client, recorder record.EventRecorder, object statusObject) *reconcileStatus {
 	before, _ := object.DeepCopyObject().(client.Object)
+	object.SetObservedGeneration(object.GetGeneration())
+	conditions := object.StatusConditions()
 	return &reconcileStatus{
 		client:           c,
 		recorder:         recorder,

--- a/internal/controller/status_observed_generation_test.go
+++ b/internal/controller/status_observed_generation_test.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	configbutleraiv1alpha3 "github.com/ConfigButler/gitops-reverser/api/v1alpha3"
+)
+
+// TestBeginStatus_StampsObservedGenerationForEveryKind checks the stamp on every kind that opens a
+// status session, because the failure it prevents is silent: an object whose observedGeneration
+// trails its generation is reported by kstatus as describing a spec nobody looked at, and nothing
+// in the status itself looks wrong. The table is the enrolment list — a sixth kind that starts
+// using the helper without appearing here is the gap this test exists to close.
+func TestBeginStatus_StampsObservedGenerationForEveryKind(t *testing.T) {
+	tests := []struct {
+		name   string
+		object statusObject
+	}{
+		{
+			name:   "GitTarget",
+			object: &configbutleraiv1alpha3.GitTarget{ObjectMeta: metav1.ObjectMeta{Generation: 7}},
+		},
+		{
+			name:   "GitProvider",
+			object: &configbutleraiv1alpha3.GitProvider{ObjectMeta: metav1.ObjectMeta{Generation: 7}},
+		},
+		{
+			name:   "ClusterProvider",
+			object: &configbutleraiv1alpha3.ClusterProvider{ObjectMeta: metav1.ObjectMeta{Generation: 7}},
+		},
+		{
+			name:   "WatchRule",
+			object: &configbutleraiv1alpha3.WatchRule{ObjectMeta: metav1.ObjectMeta{Generation: 7}},
+		},
+		{
+			name:   "ClusterWatchRule",
+			object: &configbutleraiv1alpha3.ClusterWatchRule{ObjectMeta: metav1.ObjectMeta{Generation: 7}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			st := beginStatus(nil, nil, tc.object)
+
+			assert.Equal(t, int64(7), observedGenerationOf(t, tc.object),
+				"beginStatus must stamp the generation it observed")
+
+			// The same accessor supplies the conditions, so a session that reached the wrong slice
+			// would write somewhere the object never publishes from.
+			st.set(ConditionTypeReady, metav1.ConditionTrue, ReasonSucceeded, "converged")
+			require.Len(t, *tc.object.StatusConditions(), 1)
+			assert.Equal(t, int64(7), (*tc.object.StatusConditions())[0].ObservedGeneration)
+		})
+	}
+}
+
+// observedGenerationOf reads the field back through the concrete type, which is the only side the
+// accessor interface does not expose — a getter would exist solely for this assertion.
+func observedGenerationOf(t *testing.T, object client.Object) int64 {
+	t.Helper()
+	switch o := object.(type) {
+	case *configbutleraiv1alpha3.GitTarget:
+		return o.Status.ObservedGeneration
+	case *configbutleraiv1alpha3.GitProvider:
+		return o.Status.ObservedGeneration
+	case *configbutleraiv1alpha3.ClusterProvider:
+		return o.Status.ObservedGeneration
+	case *configbutleraiv1alpha3.WatchRule:
+		return o.Status.ObservedGeneration
+	case *configbutleraiv1alpha3.ClusterWatchRule:
+		return o.Status.ObservedGeneration
+	default:
+		t.Fatalf("unexpected kind %T", object)
+		return 0
+	}
+}
+
+// TestBeginStatus_TheStampAloneIsPersisted pins the ordering inside beginStatus against commit()'s
+// no-op suppression. The snapshot the patch is computed from must be taken BEFORE the stamp: taken
+// after, a bumped generation would be identical on both sides, the patch would be empty, and a
+// reconcile that changed no condition would silently leave observedGeneration behind — which is
+// exactly the reconcile where nothing else would ever reveal it.
+func TestBeginStatus_TheStampAloneIsPersisted(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, configbutleraiv1alpha3.AddToScheme(scheme))
+
+	target := &configbutleraiv1alpha3.GitTarget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "acme", Namespace: "tenant-acme", ResourceVersion: "1", Generation: 4,
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(target).WithStatusSubresource(target).Build()
+
+	st := beginStatus(c, nil, target)
+	require.NoError(t, st.commit(context.Background()))
+
+	var stored configbutleraiv1alpha3.GitTarget
+	require.NoError(t, c.Get(context.Background(), client.ObjectKeyFromObject(target), &stored))
+	assert.Equal(t, int64(4), stored.Status.ObservedGeneration,
+		"a reconcile whose only status change is the stamp must still write it")
+}

--- a/internal/controller/stream_status_test.go
+++ b/internal/controller/stream_status_test.go
@@ -75,26 +75,24 @@ func TestCommitRule_LostWriteBeatsTheConvergingLoop(t *testing.T) {
 	tests := []struct {
 		name    string
 		commit  func(context.Context, *reconcileStatus, *readiness) (ctrl.Result, error)
-		newRule func() (client.Object, *[]metav1.Condition)
+		newRule func() statusObject
 	}{
 		{
 			name:   "WatchRule",
 			commit: (&WatchRuleReconciler{}).commitRule,
-			newRule: func() (client.Object, *[]metav1.Condition) {
-				rule := &configbutleraiv1alpha3.WatchRule{
+			newRule: func() statusObject {
+				return &configbutleraiv1alpha3.WatchRule{
 					ObjectMeta: metav1.ObjectMeta{Name: "rule", Namespace: "tenant-acme", ResourceVersion: "1"},
 				}
-				return rule, &rule.Status.Conditions
 			},
 		},
 		{
 			name:   "ClusterWatchRule",
 			commit: (&ClusterWatchRuleReconciler{}).commitRule,
-			newRule: func() (client.Object, *[]metav1.Condition) {
-				rule := &configbutleraiv1alpha3.ClusterWatchRule{
+			newRule: func() statusObject {
+				return &configbutleraiv1alpha3.ClusterWatchRule{
 					ObjectMeta: metav1.ObjectMeta{Name: "rule", ResourceVersion: "1"},
 				}
-				return rule, &rule.Status.Conditions
 			},
 		},
 	}
@@ -107,18 +105,18 @@ func TestCommitRule_LostWriteBeatsTheConvergingLoop(t *testing.T) {
 				return rd
 			}
 
-			rule, conditions := tc.newRule()
+			rule := tc.newRule()
 			landed := fake.NewClientBuilder().WithScheme(scheme).WithObjects(rule).
 				WithStatusSubresource(rule).Build()
-			result, err := tc.commit(context.Background(), beginStatus(landed, nil, rule, conditions), converging())
+			result, err := tc.commit(context.Background(), beginStatus(landed, nil, rule), converging())
 			require.NoError(t, err)
 			assert.Equal(t, RequeueStreamSettleInterval, result.RequeueAfter,
 				"a converging rule that published its status keeps the stream-settle loop")
 
-			rule, conditions = tc.newRule()
+			rule = tc.newRule()
 			lost := fake.NewClientBuilder().WithScheme(scheme).WithObjects(rule).
 				WithInterceptorFuncs(conflict).Build()
-			result, err = tc.commit(context.Background(), beginStatus(lost, nil, rule, conditions), converging())
+			result, err = tc.commit(context.Background(), beginStatus(lost, nil, rule), converging())
 			require.NoError(t, err)
 			assert.Equal(t, RequeueWriteLostInterval, result.RequeueAfter,
 				"a converging rule whose status never landed must come back promptly, not on the settle loop")

--- a/internal/controller/watchrule_controller.go
+++ b/internal/controller/watchrule_controller.go
@@ -96,8 +96,7 @@ func (r *WatchRuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		"target", watchRule.Spec.GitTargetRef,
 		"generation", watchRule.Generation,
 		"resourceVersion", watchRule.ResourceVersion)
-	st := beginStatus(r.Client, r.Recorder, &watchRule, &watchRule.Status.Conditions)
-	watchRule.Status.ObservedGeneration = watchRule.Generation
+	st := beginStatus(r.Client, r.Recorder, &watchRule)
 
 	// Seed the axis conditions as not-yet-evaluated. There is deliberately no placeholder write of
 	// the Ready/Reconciling/Stalled trio here: every path below ends in exactly one applyReadiness,


### PR DESCRIPTION
`beginStatus` stamps `status.observedGeneration` itself, instead of each of the five
config controllers hand-writing the same line after opening its session.

The line is not tidiness: a controller that omits it publishes a status kstatus reads
as Current for a spec nobody looked at, and nothing about the status itself looks wrong.

The six statuses in `api/v1alpha3` are uniform, so an accessor pair on the API types —
`SetObservedGeneration` and `StatusConditions` — lets the session do the stamp and reach
the conditions through the object rather than beside it. That drops `beginStatus`'s
fourth parameter and with it the chance of handing a session one object's conditions and
another object's metadata.

The stamp lands after the `before` snapshot is captured. The other order would leave a
reconcile whose only status change is a new `observedGeneration` producing an empty patch
and falling into `commit()`'s no-op suppression; a test pins that ordering.

`conditionMetricKind` keeps its type switch. `CommitRequest` is excluded from
`gitopsreverser_resource_condition` on purpose, and that exclusion stays structural — an
interface anything can implement is not a place to keep it. `CommitRequest` gets no
accessors either, since it does not use this helper.

CRDs and `zz_generated.deepcopy.go` are unchanged: methods do not move a schema, and
`task generate` + `task manifests` leave both untouched.

Stacked on #346 — base is `feat/metrics-cleanup`, which GitHub will retarget to `main`
when that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved status tracking for Git targets, Git providers, cluster providers, watch rules, and cluster watch rules.
  * Observed generation and status conditions are now consistently recorded during reconciliation.
  * Ensured status updates are persisted even when the observed generation is the only change.

* **Tests**
  * Added coverage verifying status accessors and observed-generation handling across supported resource types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->