### PR TITLE
feat(templates)!: place by label, one namespace variable, richer commit messages

### DIFF
--- a/api/v1alpha3/gittarget_types.go
+++ b/api/v1alpha3/gittarget_types.go
@@ -214,7 +214,7 @@ type GitTargetCommitSpec struct {
 // kustomization when the whole folder is governed by exactly one supported
 // kustomization (so the file is reachable from a render root instead of being
 // written where kustomize would never build it), and otherwise at the built-in
-// canonical, versionless {namespaceOrCluster}/{group}/{resource}/{name}.yaml path.
+// canonical, versionless {namespace}/{group}/{resource}/{name}.yaml path.
 // Nothing infers a destination from where the repository keeps other resources of
 // the same type: a layout this operator cannot derive from one root is declared
 // here or it is canonical. Because the canonical path omits the API version,

--- a/api/v1alpha3/gittarget_types.go
+++ b/api/v1alpha3/gittarget_types.go
@@ -65,10 +65,33 @@ type GitTargetSpec struct {
 	// +optional
 	Encryption *EncryptionSpec `json:"encryption,omitempty"`
 
+	// Why a "{label:key|fallback}" may start with "_" where a label value may not: a
+	// fallback that is itself label-legal shares its bucket with the resources genuinely
+	// labeled it, and nothing downstream can separate the two again. A leading "_" is the
+	// only way to name a bucket no label value can reach — the property "_unlabeled" and
+	// "_cluster" are already built on. The empty fallback is allowed for the mirror-image
+	// reason: the built-in sentinel protects the case where nobody chose, while an empty
+	// fallback is a choice spelled out in the spec, visible in review and in `kubectl get`.
+	// See docs/layout/new-file-placement-rules.md.
+
 	// Placement declares where NEW resources are written. It has no effect on a
 	// resource that already has a document in Git — that document is always
 	// updated in place at its existing location, wherever that is. Mutable: a
 	// change only affects resources created after the change.
+	//
+	// Its byType and default templates share one variable language (docs/configuration.md).
+	// Besides the resource's identity, a template may read one of its labels:
+	// "{label:app.kubernetes.io/instance}/configmaps.yaml". A resource that does not set
+	// that label, or sets it to the empty string, is still placed — it renders the built-in
+	// "_unlabeled" bucket, a value no real label can hold, so it is never confused with a
+	// resource genuinely labeled that way. "{label:key|fallback}" declares a different
+	// bucket: at most 63 characters of [A-Za-z0-9._-], neither "." nor "..", so it can add
+	// no directory and escape no path. It may start with "_" to stay collision-proof
+	// ("{label:team|_none}"), or be empty ("{label:team|}") to render nothing at all, which
+	// collapses the segment and lands unlabeled resources one directory up. A label is
+	// never identity, so it does not contribute to the identity-completeness a sensitive
+	// route requires, and because placement runs only for a resource with no document yet,
+	// labeling one afterwards never moves the file already written.
 	// +optional
 	Placement *GitTargetPlacementSpec `json:"placement,omitempty"`
 

--- a/config/crd/bases/configbutler.ai_gittargets.yaml
+++ b/config/crd/bases/configbutler.ai_gittargets.yaml
@@ -276,6 +276,20 @@ spec:
                   resource that already has a document in Git — that document is always
                   updated in place at its existing location, wherever that is. Mutable: a
                   change only affects resources created after the change.
+
+                  Its byType and default templates share one variable language (docs/configuration.md).
+                  Besides the resource's identity, a template may read one of its labels:
+                  "{label:app.kubernetes.io/instance}/configmaps.yaml". A resource that does not set
+                  that label, or sets it to the empty string, is still placed — it renders the built-in
+                  "_unlabeled" bucket, a value no real label can hold, so it is never confused with a
+                  resource genuinely labeled that way. "{label:key|fallback}" declares a different
+                  bucket: at most 63 characters of [A-Za-z0-9._-], neither "." nor "..", so it can add
+                  no directory and escape no path. It may start with "_" to stay collision-proof
+                  ("{label:team|_none}"), or be empty ("{label:team|}") to render nothing at all, which
+                  collapses the segment and lands unlabeled resources one directory up. A label is
+                  never identity, so it does not contribute to the identity-completeness a sensitive
+                  route requires, and because placement runs only for a resource with no document yet,
+                  labeling one afterwards never moves the file already written.
                 properties:
                   byType:
                     additionalProperties:

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -102,13 +102,21 @@ A few things to know before you use it:
 `{annotation:key}` is deliberately not supported: an annotation value has no length or character
 limit of its own, so it is not a path segment the way a 63-character label value is.
 
-What to check before upgrading: a placement template containing a `{…}`-shaped piece of text that
-is **not** a variable. Recognizing `{label:app.kubernetes.io/name}` means the template scanner now
-matches any `{…}`, where it previously matched only `{word}` and left everything else in the path
-as literal text. Such a template now fails the GitTarget's `Validated` gate with
-`InvalidConfig` naming the placeholder, instead of silently writing braces — and, for anything
-containing a `/`, an unintended directory — into your repository. Nothing moves a file already
-committed at such a path.
+What to check before upgrading: a placement template containing a brace that is not part of a
+variable. Recognizing `{label:app.kubernetes.io/name}` means the template scanner now matches any
+`{…}`, where it previously matched only `{word}` and left everything else in the path as literal
+text. Two shapes are now refused at the GitTarget's `Validated` gate with `InvalidConfig` instead
+of being written into your repository:
+
+- a complete `{…}` that names no variable, such as a misspelled `{namspace}`. The message names the
+  placeholder.
+- a brace belonging to no complete variable at all, such as `{namespace}/{label:team/{name}.yaml`
+  (the label placeholder never closes) or a nested `{label:{name}}`. These were the more dangerous
+  half: an unclosed placeholder is not a placeholder, so it used to render verbatim, and the
+  example above resolved to `app/{label:team/cache.yaml` — a clean relative `.yaml` path that every
+  later check accepted, so the writer created a directory literally named `{label:team`.
+
+Nothing moves a file already committed at such a path.
 
 ## A `CommitRequest` refused by someone else's window now says so
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -66,7 +66,15 @@ rejected at admission with `Validated=False`, because the sample render includes
 carries no labels.
 
 A `DELETE` event carries no object, so `Kind` and `Labels` are empty for one; every identity field
-is unaffected. `reconcileTemplate` is unchanged: it names a type rather than a list of resources.
+is unaffected.
+
+`reconcileTemplate` gains no fields, but its **default** now names the namespace of a
+namespace-scoped reconcile: `chore: reconcile 4 configmaps in team-a (last resourceVersion: 1331)`.
+A reconcile runs per (type, namespace) cell, so that run covered exactly one namespace, and without
+the name a target watching one type in several namespaces wrote identical subjects for each. A
+whole-target or all-namespaces reconcile is unchanged, because an empty `Namespace` there means the
+run was not namespace-scoped at all — a fact no single word states truthfully, so the subject
+states none.
 
 ## Placement templates can read a label, and a stray `{…}` is now an error
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -7,6 +7,67 @@ guidance that the changelog's breaking-change entries link to.
 We are pre-1.0, so breaking changes bump the **minor** version (release-please is configured with
 `bump-minor-pre-major`) rather than the major. Read the relevant entry before upgrading across it.
 
+## `{namespaceOrCluster}` is gone; `{namespace}` renders `_cluster`
+
+**Breaking for a placement template that names `{namespaceOrCluster}`.** There is now one
+namespace-position variable instead of two.
+
+`{namespace}` renders the resource's namespace, or the literal `_cluster` when the resource is
+cluster-scoped — the value `{namespaceOrCluster}` used to render, and the one the built-in
+canonical path has always used. Rename the variable:
+
+```yaml
+placement:
+  default: "{namespace}/{groupPath}/{resource}/{name}.yaml"   # was {namespaceOrCluster}
+```
+
+A GitTarget still naming `{namespaceOrCluster}` goes `Validated=False` with `InvalidConfig` and a
+message that names the replacement, so it fails at the gate rather than writing anything.
+
+**What changes for a template that already said `{namespace}`:** only cluster-scoped resources, and
+only newly created files. `{namespace}` used to render empty for one, and an empty segment is
+dropped, so `{namespace}/{resource}/{name}.yaml` filed a ClusterRole at `clusterroles/admin.yaml`
+and scattered cluster-scoped resources into the directory above the one the template named. It now
+files it at `_cluster/clusterroles/admin.yaml`. Placement is match-first, so nothing already in Git
+moves; only resources first written after the upgrade land in the new place.
+
+Why collapse the two: an empty render is the one thing a path variable must never do, since it
+folds resources onto a path the template did not describe. `{namespaceOrCluster}` existed only to
+avoid that fold, which made the safe spelling the longer one and the short, obvious spelling the
+trap. One variable that always renders a scope removes the trap instead of documenting it.
+
+## Commit message templates can read the kind, the scope sentinel, and labels
+
+**Not breaking**: existing templates render unchanged; these are additional fields.
+
+Each `Resources` entry in `liveTemplate` gains `Kind`, `Labels` and a `Label` accessor, the
+template itself gains `LabelValues` / `LabelValue`, and `Namespace` gains the scope sentinel
+described below:
+
+```yaml
+liveTemplate: |-
+  chore: sync {{.Count}} resource{{if ne .Count 1}}s{{end}}{{with .LabelValue "team"}} for {{.}}{{end}}
+
+  {{range .Resources -}}
+  - [{{.Operation}}] {{.Kind}} {{.Namespace}}/{{.Name}}
+  {{end -}}
+```
+
+`Namespace` renders `_cluster` for a cluster-scoped resource, the same value the `{namespace}`
+placement variable and the canonical path use, so a body line no longer has to guard an empty
+namespace by hand. The default template stops doing so, which changes one line of a default commit
+message: a cluster-scoped resource reads `- [CREATE] v1/nodes/_cluster/node-1` where it used to
+read `- [CREATE] v1/nodes/node-1`.
+
+Read a label with `{{.Label "team"}}`, not `{{.Labels.team}}`: these templates render with
+`missingkey=error`, so indexing a label a resource does not carry fails the render, and a failed
+render fails the commit. The accessor renders empty instead. A template using the dotted form is
+rejected at admission with `Validated=False`, because the sample render includes a resource that
+carries no labels.
+
+A `DELETE` event carries no object, so `Kind` and `Labels` are empty for one; every identity field
+is unaffected. `reconcileTemplate` is unchanged: it names a type rather than a list of resources.
+
 ## Placement templates can read a label, and a stray `{…}` is now an error
 
 **Not breaking for any valid template**, and listed here because one previously-tolerated
@@ -25,7 +86,7 @@ A few things to know before you use it:
 
 - A resource that does not set the label — or sets it to the empty string, which Kubernetes
   allows — is still placed: it renders the built-in `_unlabeled` bucket, mirroring how
-  `{namespaceOrCluster}` renders `_cluster` for a cluster-scoped resource — a fixed, documented
+  `{namespace}` renders `_cluster` for a cluster-scoped resource — a fixed, documented
   value no real label could ever hold. Use `{label:team|unassigned}` to name your own bucket
   instead; `unassigned` renders whenever the label is absent.
 - A fallback is at most 63 characters of `[A-Za-z0-9._-]` and may be neither `.` nor `..`, so it

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -65,8 +65,13 @@ render fails the commit. The accessor renders empty instead. A template using th
 rejected at admission with `Validated=False`, because the sample render includes a resource that
 carries no labels.
 
+`LabelValue "team"` renders a value only when **every** resource in the commit carries that label
+with that value; one unlabeled resource in the window leaves the subject unnamed rather than
+attributing the whole commit to the only team in it. `LabelValues "team"` is the sorted, distinct
+set and skips the unlabeled, which is what a body line ranging over teams wants.
+
 A `DELETE` event carries no object, so `Kind` and `Labels` are empty for one; every identity field
-is unaffected.
+is unaffected. That makes `LabelValue` empty for any commit containing a `DELETE`.
 
 `reconcileTemplate` gains no fields, but its **default** now names the namespace of a
 namespace-scoped reconcile: `chore: reconcile 4 configmaps in team-a (last resourceVersion: 1331)`.

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -7,6 +7,48 @@ guidance that the changelog's breaking-change entries link to.
 We are pre-1.0, so breaking changes bump the **minor** version (release-please is configured with
 `bump-minor-pre-major`) rather than the major. Read the relevant entry before upgrading across it.
 
+## Placement templates can read a label, and a stray `{…}` is now an error
+
+**Not breaking for any valid template**, and listed here because one previously-tolerated
+spelling now fails a gate that used to let it through.
+
+`spec.placement.byType` and `spec.placement.default` accept `{label:key}`, which renders the
+value of that label on the resource being placed:
+
+```yaml
+placement:
+  byType:
+    v1/configmaps: "{label:app.kubernetes.io/instance}/configmaps.yaml"
+```
+
+A few things to know before you use it:
+
+- A resource that does not set the label — or sets it to the empty string, which Kubernetes
+  allows — is still placed: it renders the built-in `_unlabeled` bucket, mirroring how
+  `{namespaceOrCluster}` renders `_cluster` for a cluster-scoped resource — a fixed, documented
+  value no real label could ever hold. Use `{label:team|unassigned}` to name your own bucket
+  instead; `unassigned` renders whenever the label is absent.
+- A fallback is at most 63 characters of `[A-Za-z0-9._-]` and may be neither `.` nor `..`, so it
+  can introduce no directory and escape no path. It may start with `_` — `{label:team|_none}`
+  names a bucket no real label value can reach, where `{label:team|unassigned}` shares one with
+  resources genuinely labeled `team: unassigned` — and it may be empty: `{label:team|}` renders
+  nothing, so the segment collapses and unlabeled resources land one directory up.
+- Where a resource lands is decided once, when its file is created. Labeling it later does not
+  move it out of `_unlabeled/`, and changing the label does not move it to the new bucket.
+- A label is not identity, so `{label:key}` never satisfies the identity-completeness a
+  sensitive (Secret) route requires. Keep `{name}` and a scope variable in those templates.
+
+`{annotation:key}` is deliberately not supported: an annotation value has no length or character
+limit of its own, so it is not a path segment the way a 63-character label value is.
+
+What to check before upgrading: a placement template containing a `{…}`-shaped piece of text that
+is **not** a variable. Recognizing `{label:app.kubernetes.io/name}` means the template scanner now
+matches any `{…}`, where it previously matched only `{word}` and left everything else in the path
+as literal text. Such a template now fails the GitTarget's `Validated` gate with
+`InvalidConfig` naming the placeholder, instead of silently writing braces — and, for anything
+containing a `/`, an unintended directory — into your repository. Nothing moves a file already
+committed at such a path.
+
 ## A `CommitRequest` refused by someone else's window now says so
 
 **Not breaking for readiness**, and listed here because it is a status value that starts appearing
@@ -913,7 +955,7 @@ New tuning knobs, all with behaviour-preserving defaults: `attribution.maxFactsP
 (10000). They bound the in-process index and the collection join; see
 [configuration.md](configuration.md).
 
-## 0.41.0 — the attribution metrics are relabelled and partly renamed (breaking for queries)
+## 0.41.0 — the attribution metrics are relabeled and partly renamed (breaking for queries)
 
 The `result` label is **gone** from `gitopsreverser_attribution_resolutions_total` and
 `gitopsreverser_attribution_resolution_wait_seconds`. It crammed two orthogonal questions into one
@@ -1180,7 +1222,7 @@ A non-zero `retainedDocuments` means the mirror holds documents a converged one 
 configured outcome, not a fault, so no condition goes `False` for it. `0` means a resync ran and
 found nothing to retain; an absent `retention` block means none has reported yet. The same event
 logs a throttled line naming the target and increments
-`gitopsreverser_prune_retained_documents_total`, labelled by GitTarget and mode. See
+`gitopsreverser_prune_retained_documents_total`, labeled by GitTarget and mode. See
 [configuration.md](configuration.md#seeing-what-was-kept).
 
 This ships in the **same release** as the rule-kind scope change below, and is what makes that

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -601,7 +601,7 @@ spec:
 | Template | Fields |
 |---|---|
 | `liveTemplate` | `Author`, `GitTarget`, `Count`, `Operations`, `Resources`, and the `LabelValues` / `LabelValue` accessors |
-| Each `Resources` entry | `Operation`, `Group`, `Version`, `Resource`, `Kind`, `Namespace`, `NamespaceOrCluster`, `Name`, `APIVersion`, `Labels`, and the `Label` accessor |
+| Each `Resources` entry | `Operation`, `Group`, `Version`, `Resource`, `Kind`, `Namespace`, `Name`, `APIVersion`, `Labels`, and the `Label` accessor |
 | `reconcileTemplate` | `Count`, `GitTarget`, `Group`, `Version`, `Resource`, `APIVersion`, `Namespace`, `Revision` |
 
 Live `Count` counts retained entries after window coalescing, before the writer compares them with
@@ -646,10 +646,13 @@ Three things to know:
 - **A commit spans n resources, so a label is a set here.** `LabelValues "team"` is the sorted,
   distinct list of values in this commit, skipping resources that do not set it; `LabelValue "team"`
   is the single value when the whole commit agrees on one, and empty when it does not. A subject
-  line that names a team is only honest under the second.
+  line that names a team is only honest under the second. The two differ on a resource that does
+  not carry the label: `LabelValues` skips it, `LabelValue` treats it as a disagreement and renders
+  nothing, so a commit holding one labeled and one unlabeled resource is named after neither.
 - **A `DELETE` carries no object**, because the resource is already gone from the cluster, so
   `Kind` and `Labels` are empty for one. The identity fields (`Name`, `Namespace`, `Resource`, …)
-  are unaffected.
+  are unaffected. A commit containing a `DELETE` therefore has no agreed `LabelValue`: what the
+  deleted resource was labeled is not something the window still knows.
 
 `reconcileTemplate` gets none of these. It describes a *type* being reconciled rather than a list
 of resources, so there are no labels to read, and its `Namespace` keeps the plain meaning it always

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -600,8 +600,8 @@ spec:
 
 | Template | Fields |
 |---|---|
-| `liveTemplate` | `Author`, `GitTarget`, `Count`, `Operations`, `Resources` |
-| Each `Resources` entry | `Operation`, `Group`, `Version`, `Resource`, `Namespace`, `Name`, `APIVersion` |
+| `liveTemplate` | `Author`, `GitTarget`, `Count`, `Operations`, `Resources`, and the `LabelValues` / `LabelValue` accessors |
+| Each `Resources` entry | `Operation`, `Group`, `Version`, `Resource`, `Kind`, `Namespace`, `NamespaceOrCluster`, `Name`, `APIVersion`, `Labels`, and the `Label` accessor |
 | `reconcileTemplate` | `Count`, `GitTarget`, `Group`, `Version`, `Resource`, `APIVersion`, `Namespace`, `Revision` |
 
 Live `Count` counts retained entries after window coalescing, before the writer compares them with
@@ -614,6 +614,70 @@ message. Printing a resource entry directly keeps its `group/version/resource[/n
 `Author` is the raw window username and is empty when no actor is named. It does not use an OIDC
 display name or the `attribution-unresolved` Git author sentinel. The sentinel appears only in the
 Git author header when attribution ran without resolving an actor. Messages never change authorship.
+
+##### Kind, scope, and labels
+
+`Kind` is the commit-message spelling of the `{kind}` [placement variable](#template-variables),
+and `Namespace` now answers the scope question completely: it renders the resource's namespace, or
+the literal `_cluster` when the resource is cluster-scoped, exactly as `{namespace}` does in a path.
+A body line no longer has to guard it with `{{if .Namespace}}`, because the field is never blank;
+the default template no longer does.
+
+`Labels` is the resource's labels as the writer commits them, and is read with the `Label`
+accessor:
+
+```yaml
+liveTemplate: |-
+  chore: sync {{.Count}} resource{{if ne .Count 1}}s{{end}}{{with .LabelValue "team"}} for {{.}}{{end}}
+
+  {{range .Resources -}}
+  - [{{.Operation}}] {{.Kind}} {{.Namespace}}/{{.Name}} ({{.Label "app.kubernetes.io/instance"}})
+  {{end -}}
+```
+
+Three things to know:
+
+- **Read a label with `{{.Label "team"}}`, never `{{.Labels.team}}`.** These templates render with
+  `missingkey=error`, so indexing a label a resource does not carry does not render empty: it fails
+  the render, and a failed render fails the whole commit, losing the window until the next resync.
+  `Label` returns the empty string instead. Validation catches the dotted form (its sample events
+  include a resource with no labels), so such a template is rejected at admission rather than at
+  2am, but the accessor is the spelling to write.
+- **A commit spans n resources, so a label is a set here.** `LabelValues "team"` is the sorted,
+  distinct list of values in this commit, skipping resources that do not set it; `LabelValue "team"`
+  is the single value when the whole commit agrees on one, and empty when it does not. A subject
+  line that names a team is only honest under the second.
+- **A `DELETE` carries no object**, because the resource is already gone from the cluster, so
+  `Kind` and `Labels` are empty for one. The identity fields (`Name`, `Namespace`, `Resource`, …)
+  are unaffected.
+
+`reconcileTemplate` gets none of these. It describes a *type* being reconciled rather than a list
+of resources, so there are no labels to read, and its `Namespace` keeps the plain meaning it always
+had: the namespace a namespace-scoped reconcile covered, empty for a whole-target or all-namespaces
+one. That emptiness means "every namespace", not "cluster-scoped", so the `_cluster` sentinel would
+be a lie there rather than a convenience.
+
+##### Two languages, one vocabulary
+
+Placement templates and commit templates are deliberately different renderers: a path has to be
+statically checkable (that is what lets the operator prove a Secret route cannot collide two
+Secrets onto one file), while a commit message has to iterate over n resources, which needs
+`range` and `if`. Neither language can do the other's job.
+
+The nouns are the same in both, and only the spelling follows each host language:
+
+| Concept | Placement | Commit message |
+|---|---|---|
+| namespace, or `_cluster` when cluster-scoped | `{namespace}` | `.Namespace` |
+| kind | `{kind}` | `.Kind` |
+| name | `{name}` | `.Name` |
+| API version | `{apiVersion}` | `.APIVersion` |
+| one label | `{label:team}` | `.Label "team"` |
+
+The capitals are Go's, not a style choice: `text/template` can only reach exported struct fields,
+which must begin with one. The braces are lower-case because a placement template reads like the
+manifest it is filing (`metadata.namespace`). A label needs a method call rather than a field on
+the commit side because a Go template field name cannot contain a `:` or a `/`.
 
 Reconcile type fields name the synced type; `Namespace` names a namespace-scoped snapshot.
 Whole-target snapshots leave those fields empty. `Revision` is the snapshot's resourceVersion and
@@ -938,7 +1002,7 @@ spec:
     byType:
       v1/configmaps: "{namespace}/configmaps.yaml"     # bundle every ConfigMap of a namespace into one file
       v1/secrets: "{namespace}/secrets/{name}.yaml"    # one file per Secret
-    default: "{namespaceOrCluster}/{group}/{resource}/{name}.yaml"
+    default: "{namespace}/{group}/{resource}/{name}.yaml"
 ```
 
 - **`byType`** maps an exact `[group/]version/resource` key (core resources omit the group, e.g.
@@ -959,8 +1023,7 @@ named `api` in namespace `team-a`:
 | Variable | Renders | Example |
 |---|---|---|
 | `{name}` | resource name | `api` |
-| `{namespace}` | the resource's namespace; **empty** for a cluster-scoped resource | `team-a` |
-| `{namespaceOrCluster}` | the namespace, or the literal `_cluster` for a cluster-scoped resource | `team-a` (a Node → `_cluster`) |
+| `{namespace}` | the resource's namespace, or the literal `_cluster` for a cluster-scoped resource | `team-a` (a Node → `_cluster`) |
 | `{resource}` | plural resource name | `deployments` |
 | `{group}` | API group; **empty** for core resources | `apps` (a ConfigMap → empty) |
 | `{groupPath}` | the API group as a path segment; equivalent to `{group}` today (the empty core-group segment is dropped either way) | `apps` |
@@ -972,16 +1035,12 @@ named `api` in namespace `team-a`:
 | `{label:key}` | the value of that label on the resource, or `_unlabeled` if it has none; the key may be prefixed (`{label:app.kubernetes.io/instance}`) | `voter` |
 | `{label:key\|fallback}` | the same, but with your own bucket in place of `_unlabeled` | `unassigned` |
 
-Two of the identity variables are easy to mix up, and only one of them places cluster-scoped
-resources sensibly:
-
-> **`{namespace}` vs `{namespaceOrCluster}`, the one to get right.** For a cluster-scoped resource
-> `{namespace}` is **empty**, so its whole path segment vanishes: a template `{namespace}/{resource}/{name}.yaml`
-> renders `clusterroles/admin.yaml` for a ClusterRole (no scope folder at all). Use `{namespaceOrCluster}`
-> when a single template must also place cluster-scoped resources; it keeps a stable `_cluster/` segment
-> (`_cluster/clusterroles/admin.yaml`) so namespaced and cluster-scoped resources stay cleanly separated.
-> `{scope}` is a *descriptor* (`cluster`/`namespaced`), not a substitute, so don't use it as the folder for
-> cluster resources.
+> **`{namespace}` always renders something.** For a cluster-scoped resource it is the literal
+> `_cluster`, so `{namespace}/{resource}/{name}.yaml` files a ClusterRole at
+> `_cluster/clusterroles/admin.yaml` and namespaced and cluster-scoped resources stay cleanly
+> separated without a second template. `_cluster` is not a legal namespace name (DNS-1123 forbids
+> `_`), so it can never collide with a real one. `{scope}` is a *descriptor* (`cluster`/
+> `namespaced`), not a substitute, so don't use it as the folder for cluster resources.
 
 #### Placing by label (`{label:key}`)
 
@@ -998,7 +1057,8 @@ placement:
 ```
 
 Resources sharing a label value bundle into one file, which is usually the point: every ConfigMap
-labeled `app.kubernetes.io/instance: voter` lands in `voter/configmaps.yaml`.
+labeled `app.kubernetes.io/instance: voter` lands in `voter/configmaps.yaml`. The commit that
+writes them can name the same label: see [Kind, scope, and labels](#kind-scope-and-labels).
 
 ##### Every resource is placed, labeled or not
 
@@ -1011,9 +1071,9 @@ carries it with an empty value, which Kubernetes permits) renders a bucket inste
 | does not set `team` | `_unlabeled` | `unassigned` | nothing; the segment collapses |
 | sets `team: ""` | `_unlabeled` | `unassigned` | nothing; the segment collapses |
 
-`_unlabeled` is the built-in bucket, and it is chosen the same way `_cluster` is for
-`{namespaceOrCluster}`: a label value has to start and end alphanumeric, so no real one can ever be
-`_unlabeled` and no real resource can land in that bucket by accident.
+`_unlabeled` is the built-in bucket, and it is chosen the same way `_cluster` is for a
+cluster-scoped `{namespace}`: a label value has to start and end alphanumeric, so no real one can
+ever be `_unlabeled` and no real resource can land in that bucket by accident.
 
 ##### Choosing your own fallback
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -595,7 +595,7 @@ spec:
         {{range .Resources -}}
         - [{{.Operation}}] {{.APIVersion}}/{{.Resource}}/{{if .Namespace}}{{.Namespace}}/{{end}}{{.Name}}
         {{end -}}
-      reconcileTemplate: "chore: reconcile {{.Count}} {{if .Resource}}{{.Resource}}{{else}}resources{{end}}{{if .Revision}} (last resourceVersion: {{.Revision}}){{end}}"
+      reconcileTemplate: "chore: reconcile {{.Count}} {{if .Resource}}{{.Resource}}{{else}}resources{{end}}{{if .Namespace}} in {{.Namespace}}{{end}}{{if .Revision}} (last resourceVersion: {{.Revision}}){{end}}"
 ```
 
 | Template | Fields |
@@ -682,6 +682,21 @@ the commit side because a Go template field name cannot contain a `:` or a `/`.
 Reconcile type fields name the synced type; `Namespace` names a namespace-scoped snapshot.
 Whole-target snapshots leave those fields empty. `Revision` is the snapshot's resourceVersion and
 can be absent, including a pure sweep. Guard optional values as in the example.
+
+A reconcile runs per *cell* (a (type, namespace) pair) rather than per target, so a
+namespace-scoped run covers exactly one namespace and the default subject names it:
+
+```text
+chore: reconcile 4 configmaps in team-a (last resourceVersion: 1331)
+```
+
+Without it, a target watching one type in two namespaces writes two byte-identical subjects, which
+is the same reason the type is in there. `Namespace` stays guarded by `{{if}}` rather than falling
+back to a sentinel the way `Resources[i].Namespace` does, and the difference is not an oversight:
+per resource, empty has exactly one meaning (the kind has no namespaces), so `_cluster` is a true
+name for it. Per run, empty covers two different facts: an all-namespaces sweep of a namespaced
+type, and a cluster-scoped type that has no namespaces. No single word is true of both, so the
+honest rendering is to say nothing.
 
 `eventTemplate` and `groupTemplate` are retired and rejected. Follow the
 [upgrade instructions](UPGRADING.md#one-live-commit-message-template) to migrate existing templates.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -969,6 +969,11 @@ named `api` in namespace `team-a`:
 | `{kind}` | manifest kind | `Deployment` |
 | `{scope}` | `namespaced` or `cluster` (a readable label, not a namespace-position value) | `namespaced` |
 | `{sensitiveSuffix}` | `.sops.yaml` for a sensitive resource, `.yaml` otherwise | `.yaml` (a Secret → `.sops.yaml`) |
+| `{label:key}` | the value of that label on the resource, or `_unlabeled` if it has none; the key may be prefixed (`{label:app.kubernetes.io/instance}`) | `voter` |
+| `{label:key\|fallback}` | the same, but with your own bucket in place of `_unlabeled` | `unassigned` |
+
+Two of the identity variables are easy to mix up, and only one of them places cluster-scoped
+resources sensibly:
 
 > **`{namespace}` vs `{namespaceOrCluster}`, the one to get right.** For a cluster-scoped resource
 > `{namespace}` is **empty**, so its whole path segment vanishes: a template `{namespace}/{resource}/{name}.yaml`
@@ -977,6 +982,85 @@ named `api` in namespace `team-a`:
 > (`_cluster/clusterroles/admin.yaml`) so namespaced and cluster-scoped resources stay cleanly separated.
 > `{scope}` is a *descriptor* (`cluster`/`namespaced`), not a substitute, so don't use it as the folder for
 > cluster resources.
+
+#### Placing by label (`{label:key}`)
+
+One variable reads the object's metadata rather than its identity. `{label:team}` renders the value
+of the resource's `team` label, and the key may be prefixed: `{label:app.kubernetes.io/instance}` is
+one variable, not a variable followed by a directory, because the template scanner takes the whole
+`{…}` including the `/` inside it. It works in `byType` and in `default` alike, and a template may
+read more than one label.
+
+```yaml
+placement:
+  byType:
+    v1/configmaps: "{label:app.kubernetes.io/instance}/configmaps.yaml"
+```
+
+Resources sharing a label value bundle into one file, which is usually the point: every ConfigMap
+labeled `app.kubernetes.io/instance: voter` lands in `voter/configmaps.yaml`.
+
+##### Every resource is placed, labeled or not
+
+There is no "not placed" state to design around. A resource that does not carry the label (or
+carries it with an empty value, which Kubernetes permits) renders a bucket instead:
+
+| The resource | `{label:team}` | `{label:team\|unassigned}` | `{label:team\|}` |
+|---|---|---|---|
+| sets `team: payments` | `payments` | `payments` | `payments` |
+| does not set `team` | `_unlabeled` | `unassigned` | nothing; the segment collapses |
+| sets `team: ""` | `_unlabeled` | `unassigned` | nothing; the segment collapses |
+
+`_unlabeled` is the built-in bucket, and it is chosen the same way `_cluster` is for
+`{namespaceOrCluster}`: a label value has to start and end alphanumeric, so no real one can ever be
+`_unlabeled` and no real resource can land in that bucket by accident.
+
+##### Choosing your own fallback
+
+`{label:key|fallback}` replaces `_unlabeled` with a bucket you name. A fallback is at most 63
+characters of `[A-Za-z0-9._-]`, may not be `.` or `..`, and may be empty. Three consequences are
+worth knowing before you pick one:
+
+- **A fallback that is a legal label value shares its bucket with resources labeled it.**
+  `{label:team|unassigned}` files unlabeled ConfigMaps exactly where `team: unassigned` ones go, and
+  nothing afterwards can tell the two apart. When you need them distinguishable, begin the fallback
+  with `_`: a label value may not start with one, so `{label:team|_none}` is a bucket only your
+  fallback can reach. That is why a fallback is allowed a leading `_` where a label value is not.
+- **An empty fallback is a request to render nothing**, and the empty segment is then dropped, so
+  unlabeled resources land one directory up: `{label:team|}/{name}.yaml` puts them at `api.yaml`
+  while labeled ones go to `payments/api.yaml`. Write it when you want the labeled resources filed
+  into folders and the rest left where they are. Only *whole* segments collapse, so inside a file
+  name `{label:team|}-{name}.yaml` renders `-api.yaml` rather than `api.yaml`.
+- **A fallback can never add a directory or escape `spec.path`**, because the character set has no
+  `/` and `..` is refused. A template that tries is rejected by the GitTarget's `Validated`
+  condition with `InvalidConfig`, before anything is written; it is not silently repaired.
+
+##### The destination is sticky
+
+Placement is match-first and runs only for a resource with no document in Git yet, so the rendered
+path is a snapshot of the label *at the moment the file was created*. Labeling a resource
+afterwards does not move it out of `_unlabeled/`, changing the label does not move it to the new
+bucket, and removing the label does not move it into one. Nothing reconciles a file's location
+against the label it carries today; if you want a resource moved, move it in Git.
+
+##### Labels the operator strips are rejected up front
+
+The writer removes controller bookkeeping (`kustomize.toolkit.fluxcd.io/*`, `kro.run/*`,
+`applyset.kubernetes.io/*`) before a document reaches Git, so those values are already gone by the
+time placement runs. A template reading one would not merely be unhelpful; every resource of its
+type would render the same fallback forever. The `Validated` gate rejects such a template by name
+rather than letting it fail silently per resource. `app.kubernetes.io/instance` is deliberately
+**not** stripped (it is indistinguishable from the standard recommended label) and stays usable.
+
+##### Two more limits
+
+- **A label is not identity.** Two resources can carry the same one, so `{label:key}` adds
+  discrimination to a path but never counts toward the identity-completeness a sensitive route
+  requires: keep `{name}` and a scope variable in those templates.
+- **`{annotation:key}` does not exist.** A label value is at most 63 path-safe characters; an
+  annotation value is unbounded text (`kubectl.kubernetes.io/last-applied-configuration` is a whole
+  JSON document), so there is no truncation rule that would not surprise somebody. Nothing else on
+  the object is exposed either; the variables above are the whole language.
 
 #### Sensitivity is a write-safety rule, not a placement setting
 

--- a/docs/design/placement-visibility-and-declared-defaults.md
+++ b/docs/design/placement-visibility-and-declared-defaults.md
@@ -65,7 +65,7 @@ objection (F9 is), and not unfixable (F4 is the fix), but it is where the idea s
 to,
 
 ```text
-{namespaceOrCluster}/{groupPath}/{resource}/{name}{sensitiveSuffix}
+{namespace}/{groupPath}/{resource}/{name}{sensitiveSuffix}
 ```
 
 is judged *not* identity-complete, and every GitTarget that did not also declare a Secret route

--- a/docs/interpreting-metrics.md
+++ b/docs/interpreting-metrics.md
@@ -202,7 +202,7 @@ boundary, the commit, the push. Background:
 | `git_queue_drops_total` | counter | `provider_namespace`, `provider_name`, `branch`, `kind` | Work a full queue threw away. `kind` is `write` / `attach` / `resync`. Every increment is lost work. |
 | `git_commit_failures_total` | counter | `provider_namespace`, `provider_name`, `branch`, `kind`, `reason` | A window or request that died between routing and pushing. `kind` is `window` / `atomic`; `reason` is `refused` (a Git path a human must fix) / `error`. Every increment is a window's events lost until the next resync. |
 | `git_queue_depth` | gauge | `provider_namespace`, `provider_name`, `branch` | Pending + in-flight + committed-but-unpushed. Read at scrape time. |
-| `git_branch_targets` | gauge | `provider_namespace`, `provider_name`, `branch`, `gittarget_namespace`, `gittarget_name`, `source_cluster` | Always 1. The **join** between the GitTarget-labelled half of the pipeline and the branch-labelled half. Published per configured GitTarget, whether or not its worker runs. |
+| `git_branch_targets` | gauge | `provider_namespace`, `provider_name`, `branch`, `gittarget_namespace`, `gittarget_name`, `source_cluster` | Always 1. The **join** between the GitTarget-labeled half of the pipeline and the branch-labeled half. Published per configured GitTarget, whether or not its worker runs. |
 | `commit_requests_total` | counter | `outcome`, `gittarget_namespace`, `gittarget_name` | One per `CommitRequest` terminal **decision**. `outcome` is `committed` / `no_window` / `window_mismatch` / `already_present` / `failed`. A target that never resolved publishes the empty pair. See the counting note below. |
 | `placements_total` | counter | `source`, `disposition`, `gittarget_namespace`, `gittarget_name`, `group`, `version`, `resource` | One per new document at a resolved path. |
 | `placement_refusals_total` | counter | `reason`, `gittarget_namespace`, `gittarget_name`, `group`, `version`, `resource` | One per new resource the writer declined. Every increment is a resource **absent** from the mirror. |
@@ -255,7 +255,7 @@ sum by (provider_namespace, provider_name, branch) (
   rate(gitopsreverser_git_pushes_total{outcome="pushed"}[15m])) > 0
 ```
 
-**Which GitTargets does that branch serve?** The push-side instruments are labelled by
+**Which GitTargets does that branch serve?** The push-side instruments are labeled by
 `{provider_namespace, provider_name, branch}` because one BranchWorker serves a (GitProvider,
 branch) that several GitTargets can share. `git_branch_targets` is the join that names them:
 
@@ -558,6 +558,13 @@ sum by (reason, gittarget_namespace, gittarget_name, resource) (
 | `multi_document_target` | the resolved file holds a document the writer cannot account for, so it will not overwrite it |
 | `unclassified` | a refusal shape newer than this table — report it |
 
+A `{label:key}` template never refuses for a missing label: a resource that does not set it lands
+at the built-in `_unlabeled` bucket, or at whatever the template's own `{label:key|fallback}` names
+— including one directory up, if that fallback is empty — so it is always mirrored somewhere. See
+[the label placement docs](layout/new-file-placement-rules.md#labelkey--the-one-metadata-variable)
+if a lot of resources are landing in `_unlabeled` and you would rather they used a declared
+fallback or a different variable.
+
 **The one that looks fine in the folder.** A new file whose `resources:` entry could not be added is
 committed and never built by kustomize: it is in Git, it looks mirrored, and nothing applies it. This
 should be zero:
@@ -859,7 +866,7 @@ or
 ```
 
 **Which transport is in force?** `gitopsreverser_attribution_transport_info` is an info gauge whose
-value is always 1, labelled `redis` or `memory`. It is a legend rather than a threshold, and it
+value is always 1, labeled `redis` or `memory`. It is a legend rather than a threshold, and it
 changes how every metric above reads: a burst of unresolved commits after a restart is *expected*
 under the in-process transport, which drops every fact with the process, and a *bug* under Redis.
 
@@ -1014,7 +1021,7 @@ Secrets are never committed in plaintext; these metrics confirm the encryption p
 
 | Metric | Type | Notes |
 | --- | --- | --- |
-| `secret_encryptions_total` | counter | One per encryption decision, labelled `outcome`: `encrypted`, `failed` (the write is rejected), or `cached` (unchanged content reused). |
+| `secret_encryptions_total` | counter | One per encryption decision, labeled `outcome`: `encrypted`, `failed` (the write is rejected), or `cached` (unchanged content reused). |
 
 **Encryption failure rate** — should be zero; non-zero means Secret writes are being rejected:
 

--- a/docs/layout/new-file-placement-rules.md
+++ b/docs/layout/new-file-placement-rules.md
@@ -12,7 +12,8 @@
 > by B2 on the same branch before release; Option A remains deferred. See
 > "Sensitivity as a write-safety classifier (B2 implementation notes)" below for how
 > the encryption guarantee is preserved without the API-level split.
-> Captured: 2026-06-05. Option C removed: 2026-07-29.
+> Captured: 2026-06-05. Option C removed: 2026-07-29. `{label:key}` added: 2026-09-11
+> (`{annotation:key}` declined with it — see "What is deliberately not exposed").
 > Related:
 > [open-asks-priority.md](../design/open-asks-priority.md) — **the argument for deleting Option C**,
 > [contextual-namespace.md](contextual-namespace.md),
@@ -925,6 +926,7 @@ Recommended variables:
 | `{namespaceOrCluster}` | namespace, or `_cluster` (an illegal-namespace sentinel, so it never collides with a real namespace) for cluster-scoped resources |
 | `{name}` | metadata name |
 | `{sensitiveSuffix}` | Optional convention helper: `.sops.yaml` for sensitive writes, `.yaml` otherwise |
+| `{label:key}` | the value of that label on the placed resource, or the `_unlabeled` sentinel when it carries none; `{label:key\|fallback}` names a different bucket, and an empty fallback renders no segment at all ([details](#labelkey--the-one-metadata-variable)) |
 
 **A template carries its own extension.** Nothing is appended: `"{namespace}/{name}"` is rejected by
 [path validation](#path-validation), which requires a recognized YAML suffix, and
@@ -987,21 +989,119 @@ default/secrets/app.yaml
 before release. Because placement is match-first for existing files, the change only
 affects newly-created files and never moves one already in Git.)
 
-Optional future variables can expose selected object metadata:
+### `{label:key}` — the one metadata variable
+
+One variable reads the object's metadata rather than its identity:
 
 | Variable | Meaning |
 |---|---|
-| `{label:key}` | sanitized value of a metadata label |
-| `{annotation:key}` | sanitized value of a metadata annotation |
+| `{label:key}` | the value of that label on the placed resource |
 
-Those are useful, but they should not be day-one unless there is a strong need.
-Labels and annotations can change. Placement is create-time and non-retroactive,
-so changing a label later would not move the file, but it can still surprise
-users who expected the path to track metadata.
+`{label:app.kubernetes.io/instance}` renders that label's value. The key is a
+Kubernetes qualified name, so it may carry a `/` prefix; the placeholder scanner
+matches anything `{…}`-shaped precisely so that `/` is consumed as part of the
+variable name instead of becoming a directory separator.
 
-Do not expose arbitrary object fields such as `{spec.foo}` in the first version.
-That makes path policy depend on mutable, schema-specific content and pulls the
-placement layer into every CRD's structure.
+**A missing label never blocks placement.** If the resource does not set the
+label (or sets it to the empty string, which Kubernetes permits) the variable
+renders the built-in sentinel `_unlabeled` rather than an empty segment — an
+empty segment would collapse and fold every unlabeled resource of the type onto
+one path, so it is replaced with a real, fixed segment instead.
+
+`_unlabeled` plays exactly the role `_cluster` already plays for
+`{namespaceOrCluster}`: a value no real label could ever hold — a label value
+must be alphanumeric at both ends, and `_unlabeled` starts with `_` — so it can
+never collide with one, and it is one documented constant rather than an
+invisible per-deployment default a reader would have to guess at.
+
+A template that would rather name its own bucket than use `_unlabeled` says so,
+with `{label:key|fallback}`:
+
+```yaml
+placement:
+  byType:
+    v1/configmaps: "{label:team|unassigned}/configmaps.yaml"
+```
+
+A fallback is held to **half** of the label-value rules: at most 63 characters
+of `[A-Za-z0-9._-]`, and neither `.` nor `..`. That is the half which makes a
+string safe as one path segment, so a declared fallback can no more introduce a
+`/` or escape the write jail than a real label value can.
+
+The half deliberately dropped is the label rule that a value start and end
+alphanumeric, and dropping it buys two things that the label-value rules would
+have forbidden:
+
+- **A fallback may begin with `_`.** A fallback that is itself a legal label
+  value shares its bucket with the resources genuinely labeled it —
+  `{label:team|unassigned}` files unlabeled resources exactly where
+  `team: unassigned` goes, and nothing downstream can separate them again. A
+  leading `_` is the only way to name a bucket no label value can reach, which
+  is the same property `_unlabeled` and `_cluster` are built on. Forcing the
+  fallback to be label-legal would have made every custom bucket collidable and
+  left the collision-proof one reserved for the operator.
+- **A fallback may be empty.** `{label:key|}` renders nothing, so
+  `collapseEmptyPathSegments` drops the segment and an unlabeled resource lands
+  one directory up — labeled resources filed into folders, the rest left at the
+  top level. That is the same fold `_unlabeled` exists to prevent, and it is
+  allowed here for a reason the default cannot claim: the sentinel protects the
+  case where nobody chose, while an empty fallback is a choice spelled out in
+  the GitTarget, visible in review and in `kubectl get gittarget -o yaml`. The
+  fence that matters is unaffected: only whole empty segments collapse, so a
+  file name keeps whatever literal text surrounds the placeholder.
+
+This sentinel design is a deliberate change from the first cut of this feature,
+which refused the resource outright when the label was missing — a resource that
+never got labeled was simply never written to Git, its absence surfacing only as
+a refusal counter rather than in the folder or in GitTarget status. For a mirror
+whose whole job is completeness, that traded a "wrong but visible" outcome for a
+worse one: a permanent, silent hole in exactly the observability tool built to
+catch holes. Placing at `_unlabeled` keeps every resource in the mirror and
+keeps the "where did this go, and why" answer in the same place — the rendered
+path — that every other placement decision already lives in. No
+`reason="missing_label"` refusal exists, and none ever shipped.
+
+The trade that refusal was protecting against is real and does not go away: this
+is **sticky**, because placement is match-first. A resource that lands in
+`_unlabeled/` (or a declared fallback bucket) stays there after somebody adds
+the label, a relabeled resource stays in the bucket its old value named, and a
+resource whose label is removed stays where the value put it. Nothing
+reconciles a document's location against the label it carries today. That is the
+same trade `placement.byType`/`placement.default` already make for every other
+template — match-first is a property of placement generally, not something
+specific to labels — so it is not a new risk, only a familiar one applied here
+too.
+
+**A label the writer strips is rejected at the `Validated` gate.** The sanitizer
+removes controller bookkeeping — `kustomize.toolkit.fluxcd.io/*`, `kro.run/*`,
+`applyset.kubernetes.io/*` — before a document reaches Git, so the value is gone
+by the time placement runs. A template reading one of those would not be a
+template that sometimes refuses; it would refuse every resource of its type
+forever. The gate says so instead. Note that `app.kubernetes.io/instance` is
+deliberately **not** stripped (see `isOperationalLabel`), so it remains usable.
+
+**A label is never identity.** Two resources in one namespace can carry the same
+label, so `{label:key}` adds discrimination to a path but can never supply the
+`{name}`/scope part that makes a template identity-complete. The sensitive-route
+rules are unchanged by it.
+
+**The mutability caveat stands.** Placement is create-time and non-retroactive: a
+label that changes later does not move the file already written. The path is a
+snapshot of the label at creation, not a view of it.
+
+### What is deliberately not exposed
+
+`{annotation:key}` is **not** a variable, and the difference from labels is not
+taste. A label value is constrained by the API server to at most 63 characters of
+`[A-Za-z0-9._-]`, which is exactly a safe path segment. An annotation value is
+arbitrary text of arbitrary length — `kubectl.kubernetes.io/last-applied-configuration`
+is a JSON document — so exposing it would mean inventing a truncation and
+escaping policy whose output nobody can predict from the object. Add it only
+behind a concrete use case that a label cannot serve.
+
+Do not expose arbitrary object fields such as `{spec.foo}`. That makes path
+policy depend on mutable, schema-specific content and pulls the placement layer
+into every CRD's structure.
 
 ## Path validation
 
@@ -1318,7 +1418,7 @@ catch-all layout.
    - never let a sensitive resource join a plaintext file, or a plaintext resource an
      encrypted one; refuse instead, with a bounded reason;
    - count every resolution by `{source, disposition}` and every refusal by `{reason}`,
-     labelled with the GitTarget and the type, which is the smaller obligation that
+     labeled with the GitTarget and the type, which is the smaller obligation that
      replaces P8's never-built cohort trace.
 5. Parse and validate path templates once per GitTarget reconcile. Sensitive
    resources must resolve to identity-complete paths and must be written through
@@ -1405,7 +1505,7 @@ Resolution-ladder unit tests:
 
 Metric tests (`internal/git/placement_metrics_test.go`), driving the real write path:
 
-- a canonical fall-back is labelled with the GitTarget and the type key a `byType` line
+- a canonical fall-back is labeled with the GitTarget and the type key a `byType` line
   would name — the labels are the feature, so they are asserted rather than the count alone;
 - declared and kustomize-root placements are distinguishable from canonical, and
   `kustomize_root` is never counted as a fall-back;
@@ -1432,8 +1532,14 @@ Integration/e2e tests:
   an explicit catch-all, or should the controller append the canonical fallback
   implicitly? This document recommends explicit catch-all rules because they make
   the user's layout complete on the page.
-- Should `{label:key}` and `{annotation:key}` ship in v1, or wait until somebody
-  has a concrete use case?
+- ~~Should `{label:key}` and `{annotation:key}` ship in v1, or wait until somebody
+  has a concrete use case?~~ **Closed, split.** `{label:key}` ships; a missing
+  label renders the built-in `_unlabeled` sentinel rather than refusing, and
+  `{label:key|fallback}` overrides that sentinel with a declared bucket — which
+  may start with `_` to stay collision-proof, or be empty to collapse the
+  segment. See [its section above](#labelkey--the-one-metadata-variable).
+  `{annotation:key}` is declined: an annotation value is unbounded text, so it is
+  not a path segment the way a label value is.
 - Should `discovery.recurse: false` survive the newer "whole folder ownership"
   model, or should flat discovery be dropped before placement rules land?
 - Should placement rule matches include `watchRuleNames` later for users who want

--- a/docs/layout/new-file-placement-rules.md
+++ b/docs/layout/new-file-placement-rules.md
@@ -29,7 +29,7 @@
 > gets its path from the GitTarget's declared `placement.byType`/`placement.default`
 > (Option B2); failing that, from the folder's one supported kustomization root, if it has
 > exactly one; failing that, from the built-in canonical
-> `{namespaceOrCluster}/{group}/{resource}/{name}.yaml` path. Nothing reads the layout of
+> `{namespace}/{group}/{resource}/{name}.yaml` path. Nothing reads the layout of
 > the other documents of the same type. Option C did exactly that and was deleted — the
 > argument is in [`open-asks-priority.md`](../design/open-asks-priority.md) and summarised
 > in [its own section below](#option-c-follow-the-existing-layout-sibling-inference--removed).
@@ -96,7 +96,7 @@ spec:
     byType:
       v1/secrets: "{namespace}/secret-{name}.yaml"
       v1/configmaps: "{namespace}/configmaps.yaml"
-    default: "{groupPath}/{version}/{resource}/{namespaceOrCluster}/{name}.yaml"
+    default: "{groupPath}/{version}/{resource}/{namespace}/{name}.yaml"
 ```
 
 In this example:
@@ -173,7 +173,7 @@ shape is:
 spec:
   placement:
     sensitiveRules:
-      - path: "{groupPath}/{version}/{resource}/{namespaceOrCluster}/{name}.sops.yaml"
+      - path: "{groupPath}/{version}/{resource}/{namespace}/{name}.sops.yaml"
     normalRules:
       - match:
           apiGroups: [""]
@@ -241,7 +241,7 @@ spec:
   placement:
     sensitiveTypes:
       v1/secrets: "{namespace}/secret-{name}.sops.yaml"
-    sensitiveDefault: "{groupPath}/{version}/{resource}/{namespaceOrCluster}/{name}.sops.yaml"
+    sensitiveDefault: "{groupPath}/{version}/{resource}/{namespace}/{name}.sops.yaml"
     normalTypes:
       v1/configmaps: "{namespace}/configmaps.yaml"
     normalDefault: "all.yaml"
@@ -302,7 +302,7 @@ placement:
   sensitive:
     byType:
       v1/secrets: "{namespace}/secret-{name}.sops.yaml"
-    default: "{groupPath}/{version}/{resource}/{namespaceOrCluster}/{name}.sops.yaml"
+    default: "{groupPath}/{version}/{resource}/{namespace}/{name}.sops.yaml"
   normal:
     byType:
       v1/configmaps: "{namespace}/configmaps.yaml"
@@ -411,7 +411,7 @@ placement:
   byType:
     v1/secrets: "{namespace}/secrets/{name}.yaml"
     v1/configmaps: "{namespace}/configmaps.yaml"
-  default: "{groupPath}/{version}/{resource}/{namespaceOrCluster}/{name}.yaml"
+  default: "{groupPath}/{version}/{resource}/{namespace}/{name}.yaml"
 ```
 
 ```go
@@ -443,7 +443,7 @@ The important safety rule moves from the API shape into validation:
   `{namespace}/{name}.yaml`;
 - a `default` that can catch sensitive resources must be identity-complete across
   type, scope, and name, for example
-  `{groupPath}/{version}/{resource}/{namespaceOrCluster}/{name}.yaml`;
+  `{groupPath}/{version}/{resource}/{namespace}/{name}.yaml`;
 - a broad bundling default such as `all.yaml` is valid only if it cannot catch
   sensitive resources, for example because every sensitive type watched by the
   target has an exact `byType` entry or because the target has no sensitive
@@ -588,7 +588,7 @@ and each one either answers or declines:
 | 1a | declared `placement.byType` for this exact type | `by_type` | the GitTarget named this type |
 | 1b | declared `placement.default`, the catch-all | `default` | the GitTarget named a fallback |
 | 2 | the folder's single supported kustomization root | `kustomize_root` | a file that root cannot reach never renders |
-| 3 | canonical `{namespaceOrCluster}/{group}/{resource}/{name}.yaml` | `canonical` | nothing else did |
+| 3 | canonical `{namespace}/{group}/{resource}/{name}.yaml` | `canonical` | nothing else did |
 
 Every resolved path — whichever step produced it — then passes one gate before a byte is
 written: [path validation](#path-validation), the append-safety rules, and the
@@ -598,7 +598,7 @@ being merely logged.
 
 ### The kustomize-root fallback
 
-The canonical path is a `{namespaceOrCluster}/{group}/{resource}/{name}.yaml` tree a
+The canonical path is a `{namespace}/{group}/{resource}/{name}.yaml` tree a
 kustomization's `resources:` graph can never reach. So in a folder that kustomize builds,
 a new document at the canonical path is not merely oddly placed — it is **never rendered**,
 and nothing applies it. That is the failure new-file placement exists to prevent, and it is
@@ -860,7 +860,7 @@ sensitive resources in the GitTarget. There are two ways a template can prove
 that:
 
 1. The path contains the full API identity variables:
-   `{groupPath}`, `{version}`, `{resource}`, `{namespaceOrCluster}`, and `{name}`.
+   `{groupPath}`, `{version}`, `{resource}`, `{namespace}`, and `{name}`.
 2. The placement entry narrows to exactly one served resource type, and the path
    contains the scope identity for that type:
    `{namespace}` plus `{name}` for namespaced resources, or `{name}` for
@@ -886,7 +886,7 @@ If the match does not narrow to one type, use the full identity path:
 
 ```yaml
 placement:
-  default: "{groupPath}/{version}/{resource}/{namespaceOrCluster}/{name}.yaml"
+  default: "{groupPath}/{version}/{resource}/{namespace}/{name}.yaml"
 ```
 
 `.sops.yaml` and `.sops.yml` remain good conventions, and the built-in secure
@@ -899,7 +899,7 @@ Variable expansion must also be non-lossy for identity variables. Do not use a
 sanitizer that turns two legal Kubernetes names into the same path segment.
 Percent-encoding or another reversible path encoding is safer than lossy
 replacement for `{groupPath}`, `{version}`, `{resource}`, `{namespace}`,
-`{namespaceOrCluster}`, and `{name}`.
+`{namespace}`, and `{name}`.
 
 ## Template variables
 
@@ -922,8 +922,7 @@ Recommended variables:
 | `{resource}` | plural resource name, for example `configmaps` |
 | `{kind}` | manifest kind, for example `ConfigMap` |
 | `{scope}` | `namespaced` or `cluster` |
-| `{namespace}` | metadata namespace, empty for cluster-scoped resources |
-| `{namespaceOrCluster}` | namespace, or `_cluster` (an illegal-namespace sentinel, so it never collides with a real namespace) for cluster-scoped resources |
+| `{namespace}` | the resource's namespace, or `_cluster` (an illegal-namespace sentinel, so it never collides with a real namespace) for a cluster-scoped resource |
 | `{name}` | metadata name |
 | `{sensitiveSuffix}` | Optional convention helper: `.sops.yaml` for sensitive writes, `.yaml` otherwise |
 | `{label:key}` | the value of that label on the placed resource, or the `_unlabeled` sentinel when it carries none; `{label:key\|fallback}` names a different bucket, and an empty fallback renders no segment at all ([details](#labelkey--the-one-metadata-variable)) |
@@ -944,7 +943,7 @@ With those variables, the built-in canonical layout is **namespace-first, no
 version segment** (as implemented in `ResourceIdentifier.ToGitPath`):
 
 ```text
-{namespaceOrCluster}/{groupPath}/{resource}/{name}{sensitiveSuffix}
+{namespace}/{groupPath}/{resource}/{name}{sensitiveSuffix}
 ```
 
 The scope leads (a real namespace, or the literal `_cluster` for a cluster-scoped
@@ -1008,8 +1007,8 @@ renders the built-in sentinel `_unlabeled` rather than an empty segment — an
 empty segment would collapse and fold every unlabeled resource of the type onto
 one path, so it is replaced with a real, fixed segment instead.
 
-`_unlabeled` plays exactly the role `_cluster` already plays for
-`{namespaceOrCluster}`: a value no real label could ever hold — a label value
+`_unlabeled` plays exactly the role `_cluster` already plays for a
+cluster-scoped resource's `{namespace}`: a value no real label could ever hold — a label value
 must be alphanumeric at both ends, and `_unlabeled` starts with `_` — so it can
 never collide with one, and it is one documented constant rather than an
 invisible per-deployment default a reader would have to guess at.
@@ -1238,7 +1237,7 @@ placement:
   byType:
     v1/secrets: "{namespace}/secret-{name}.yaml"
     v1/configmaps: "{namespace}/configmaps.yaml"
-  default: "{groupPath}/{version}/{resource}/{namespaceOrCluster}/{name}.yaml"
+  default: "{groupPath}/{version}/{resource}/{namespace}/{name}.yaml"
 ```
 
 The keys are plural resource keys, so use `v1/secrets` and `v1/configmaps`, not
@@ -1256,7 +1255,7 @@ resources get their own bundle.
 ```yaml
 placement:
   sensitiveRules:
-    - path: "{groupPath}/{version}/{resource}/{namespaceOrCluster}/{name}.yaml"
+    - path: "{groupPath}/{version}/{resource}/{namespace}/{name}.yaml"
   normalRules:
     - match:
         scope: Namespaced
@@ -1291,7 +1290,7 @@ used here as a repository convention, but it is not part of the safety contract.
 ```yaml
 placement:
   sensitiveRules:
-    - path: "{groupPath}/{version}/{resource}/{namespaceOrCluster}/{name}.yaml"
+    - path: "{groupPath}/{version}/{resource}/{namespace}/{name}.yaml"
   normalRules:
     - match:
         apiGroups: [""]

--- a/internal/controller/gittarget_placement_validation.go
+++ b/internal/controller/gittarget_placement_validation.go
@@ -8,6 +8,7 @@ import (
 
 	configbutleraiv1alpha3 "github.com/ConfigButler/gitops-reverser/api/v1alpha3"
 	"github.com/ConfigButler/gitops-reverser/internal/manifestanalyzer"
+	"github.com/ConfigButler/gitops-reverser/internal/sanitize"
 )
 
 // coreSecretsTypeKey is the placement byType key for core Kubernetes Secrets — the
@@ -100,6 +101,25 @@ func validatePlacementTemplate(tmpl string) (string, bool) {
 	}
 	if err := manifestanalyzer.ValidPlacementTemplatePath(tmpl); err != nil {
 		return err.Error(), true
+	}
+	return validatePlacementTemplateLabels(tmpl)
+}
+
+// validatePlacementTemplateLabels rejects a template reading a label the writer strips before a
+// byte reaches Git (Flux's kustomize.toolkit.fluxcd.io/*, kro.run/*, applyset.kubernetes.io/*).
+// The value is gone by the time placement runs, so every resource of the type would render the
+// same fallback (or the built-in sentinel) regardless of what it is actually labeled — the
+// template can never do the per-label split its author wrote it for. That is exactly the fault a
+// static gate exists to turn into a visible condition.
+func validatePlacementTemplateLabels(tmpl string) (string, bool) {
+	for _, key := range manifestanalyzer.PlacementTemplateLabelKeys(tmpl) {
+		if sanitize.IsStrippedLabel(key) {
+			return fmt.Sprintf(
+				"placement template %q reads label %q, which is stripped from every document before "+
+					"it is written to Git, so every resource of its type would render the same fallback",
+				tmpl, key,
+			), true
+		}
 	}
 	return "", false
 }

--- a/internal/controller/gittarget_placement_validation.go
+++ b/internal/controller/gittarget_placement_validation.go
@@ -69,8 +69,8 @@ func validateSecretSafety(spec *configbutleraiv1alpha3.GitTargetPlacementSpec) (
 
 	if secretTmpl != "" && !secretRouteComplete {
 		return false, fmt.Sprintf(
-			"placement byType[%q] %q must be identity-complete (include {name} and "+
-				"{namespace}/{namespaceOrCluster}) because Secrets are sensitive and must never share a file",
+			"placement byType[%q] %q must be identity-complete (include {name} and {namespace}) "+
+				"because Secrets are sensitive and must never share a file",
 			coreSecretsTypeKey, secretTmpl,
 		)
 	}

--- a/internal/controller/gittarget_placement_validation_test.go
+++ b/internal/controller/gittarget_placement_validation_test.go
@@ -50,6 +50,74 @@ func TestValidatePlacementPolicy(t *testing.T) {
 			true,
 		},
 		{
+			"a label variable passes the static gate with no object to read it from",
+			&configbutleraiv1alpha3.GitTargetPlacementSpec{
+				Default: "{label:app.kubernetes.io/instance}/{namespaceOrCluster}/" +
+					"{groupPath}/{resource}/{name}.yaml",
+			},
+			true,
+		},
+		{
+			"a label does not supply the type identity a default needs to stay Secret-safe",
+			&configbutleraiv1alpha3.GitTargetPlacementSpec{
+				Default: "{label:app.kubernetes.io/instance}/{namespaceOrCluster}/{name}.yaml",
+			},
+			false,
+		},
+		{
+			"a fallback bucket no label value could reach is accepted",
+			&configbutleraiv1alpha3.GitTargetPlacementSpec{
+				Default: "{label:team|_none}/{namespaceOrCluster}/{groupPath}/{resource}/{name}.yaml",
+			},
+			true,
+		},
+		{
+			"an empty fallback is a declared segment collapse, not a typo",
+			&configbutleraiv1alpha3.GitTargetPlacementSpec{
+				Default: "{label:team|}/{namespaceOrCluster}/{groupPath}/{resource}/{name}.yaml",
+			},
+			true,
+		},
+		{
+			"a fallback that would invent a directory is rejected",
+			&configbutleraiv1alpha3.GitTargetPlacementSpec{
+				Default: "{label:team|a/b}/{namespaceOrCluster}/{groupPath}/{resource}/{name}.yaml",
+			},
+			false,
+		},
+		{
+			"a label key Kubernetes would reject is rejected here, not per resource",
+			&configbutleraiv1alpha3.GitTargetPlacementSpec{
+				Default: "{label:not a key}/{namespaceOrCluster}/{name}.yaml",
+			},
+			false,
+		},
+		{
+			"a label the writer strips can never place anything, so it is rejected at the gate",
+			&configbutleraiv1alpha3.GitTargetPlacementSpec{
+				ByType: map[string]string{
+					"v1/configmaps": "{label:kustomize.toolkit.fluxcd.io/name}/configmaps.yaml",
+				},
+			},
+			false,
+		},
+		{
+			"app.kubernetes.io/instance survives sanitization and stays usable",
+			&configbutleraiv1alpha3.GitTargetPlacementSpec{
+				ByType: map[string]string{
+					"v1/configmaps": "{label:app.kubernetes.io/instance}/configmaps.yaml",
+				},
+			},
+			true,
+		},
+		{
+			"annotations are not a placement variable",
+			&configbutleraiv1alpha3.GitTargetPlacementSpec{
+				Default: "{annotation:team}/{namespaceOrCluster}/{name}.yaml",
+			},
+			false,
+		},
+		{
 			"bundling default with no Secret route is rejected",
 			&configbutleraiv1alpha3.GitTargetPlacementSpec{
 				Default: "all.yaml",

--- a/internal/controller/gittarget_placement_validation_test.go
+++ b/internal/controller/gittarget_placement_validation_test.go
@@ -30,7 +30,7 @@ func TestValidatePlacementPolicy(t *testing.T) {
 			"byType plus an identity-complete default",
 			&configbutleraiv1alpha3.GitTargetPlacementSpec{
 				ByType:  map[string]string{"v1/configmaps": "{namespace}/configmaps.yaml"},
-				Default: "{groupPath}/{version}/{resource}/{namespaceOrCluster}/{name}.yaml",
+				Default: "{groupPath}/{version}/{resource}/{namespace}/{name}.yaml",
 			},
 			true,
 		},
@@ -45,14 +45,14 @@ func TestValidatePlacementPolicy(t *testing.T) {
 		{
 			"the versionless canonical default is accepted (#295)",
 			&configbutleraiv1alpha3.GitTargetPlacementSpec{
-				Default: "{namespaceOrCluster}/{groupPath}/{resource}/{name}.yaml",
+				Default: "{namespace}/{groupPath}/{resource}/{name}.yaml",
 			},
 			true,
 		},
 		{
 			"a label variable passes the static gate with no object to read it from",
 			&configbutleraiv1alpha3.GitTargetPlacementSpec{
-				Default: "{label:app.kubernetes.io/instance}/{namespaceOrCluster}/" +
+				Default: "{label:app.kubernetes.io/instance}/{namespace}/" +
 					"{groupPath}/{resource}/{name}.yaml",
 			},
 			true,
@@ -60,35 +60,35 @@ func TestValidatePlacementPolicy(t *testing.T) {
 		{
 			"a label does not supply the type identity a default needs to stay Secret-safe",
 			&configbutleraiv1alpha3.GitTargetPlacementSpec{
-				Default: "{label:app.kubernetes.io/instance}/{namespaceOrCluster}/{name}.yaml",
+				Default: "{label:app.kubernetes.io/instance}/{namespace}/{name}.yaml",
 			},
 			false,
 		},
 		{
 			"a fallback bucket no label value could reach is accepted",
 			&configbutleraiv1alpha3.GitTargetPlacementSpec{
-				Default: "{label:team|_none}/{namespaceOrCluster}/{groupPath}/{resource}/{name}.yaml",
+				Default: "{label:team|_none}/{namespace}/{groupPath}/{resource}/{name}.yaml",
 			},
 			true,
 		},
 		{
 			"an empty fallback is a declared segment collapse, not a typo",
 			&configbutleraiv1alpha3.GitTargetPlacementSpec{
-				Default: "{label:team|}/{namespaceOrCluster}/{groupPath}/{resource}/{name}.yaml",
+				Default: "{label:team|}/{namespace}/{groupPath}/{resource}/{name}.yaml",
 			},
 			true,
 		},
 		{
 			"a fallback that would invent a directory is rejected",
 			&configbutleraiv1alpha3.GitTargetPlacementSpec{
-				Default: "{label:team|a/b}/{namespaceOrCluster}/{groupPath}/{resource}/{name}.yaml",
+				Default: "{label:team|a/b}/{namespace}/{groupPath}/{resource}/{name}.yaml",
 			},
 			false,
 		},
 		{
 			"a label key Kubernetes would reject is rejected here, not per resource",
 			&configbutleraiv1alpha3.GitTargetPlacementSpec{
-				Default: "{label:not a key}/{namespaceOrCluster}/{name}.yaml",
+				Default: "{label:not a key}/{namespace}/{name}.yaml",
 			},
 			false,
 		},
@@ -113,7 +113,7 @@ func TestValidatePlacementPolicy(t *testing.T) {
 		{
 			"annotations are not a placement variable",
 			&configbutleraiv1alpha3.GitTargetPlacementSpec{
-				Default: "{annotation:team}/{namespaceOrCluster}/{name}.yaml",
+				Default: "{annotation:team}/{namespace}/{name}.yaml",
 			},
 			false,
 		},
@@ -156,7 +156,7 @@ func TestValidatePlacementPolicy(t *testing.T) {
 		{
 			"unknown template variable",
 			&configbutleraiv1alpha3.GitTargetPlacementSpec{
-				Default: "{groupPath}/{version}/{resource}/{namespaceOrCluster}/{name}-{bogus}.yaml",
+				Default: "{groupPath}/{version}/{resource}/{namespace}/{name}-{bogus}.yaml",
 			},
 			false,
 		},

--- a/internal/git/commit.go
+++ b/internal/git/commit.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing/object"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/ConfigButler/gitops-reverser/internal/types"
@@ -131,6 +132,13 @@ func ValidateCommitConfig(config CommitConfig) error {
 		return err
 	}
 
+	// One sample carries an object with labels and a kind, and the others carry none, so both
+	// directions of a metadata-reading template are exercised here: the render with the label
+	// present, and the render without it. That second one is the important half — these
+	// templates run with missingkey=error, so "{{.Labels.team}}" fails for a resource that does
+	// not carry "team", and failing at admission is the difference between a rejected GitTarget
+	// and a commit that dies mid-window months later. "{{.Label \"team\"}}" renders empty and
+	// passes both.
 	for _, author := range []string{"template-validator", ""} {
 		var events []Event
 		for _, operation := range []string{"CREATE", "UPDATE", "DELETE"} {
@@ -138,6 +146,9 @@ func ValidateCommitConfig(config CommitConfig) error {
 			event.UserInfo.Username = author
 			event.Operation = operation
 			event.Identifier.Name = operation
+			if operation == "CREATE" {
+				event.Object = sampleLabeledObject()
+			}
 			events = append(events, event)
 			if _, err := renderLiveCommitMessage(PendingWrite{
 				Kind: PendingWriteCommit, Events: events,
@@ -148,6 +159,24 @@ func ValidateCommitConfig(config CommitConfig) error {
 	}
 
 	return nil
+}
+
+// sampleLabeledObject is the object the commit-template validator hands one of its sample
+// events: enough metadata for {{.Kind}} and a label accessor to render, and deliberately not
+// handed to the DELETE sample, which carries no object in production either.
+func sampleLabeledObject() *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata": map[string]any{
+			"name":      "example",
+			"namespace": "default",
+			"labels": map[string]any{
+				"app.kubernetes.io/instance": "example",
+				"team":                       "example-team",
+			},
+		},
+	}}
 }
 
 func operatorSignature(config CommitConfig, when time.Time) *object.Signature {

--- a/internal/git/commit_metadata_fields_test.go
+++ b/internal/git/commit_metadata_fields_test.go
@@ -122,6 +122,55 @@ func TestLiveCommitMessageData_LabelValue_AgreedValue(t *testing.T) {
 	}
 }
 
+// A resource that does not carry the label disagrees; it does not abstain. Reading the value off
+// LabelValues (which skips the unlabeled) named a mixed commit after the only team in it, so
+// "chore: sync 2 resources for payments" described a commit half of which nobody can attribute.
+func TestLiveCommitMessageData_LabelValue_PartiallyLabeledCommitNamesNoOne(t *testing.T) {
+	labeled := labeledDeploymentEvent("api", "prod", map[string]string{"team": "payments"})
+
+	for _, tc := range []struct {
+		name  string
+		other Event
+	}{
+		{"no labels at all", labeledDeploymentEvent("bare", "prod", nil)},
+		{"the label empty", labeledDeploymentEvent("blank", "prod", map[string]string{"team": ""})},
+		{"a different label", labeledDeploymentEvent("other", "prod", map[string]string{"squad": "payments"})},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			data := buildLiveCommitMessageData("someone", "target", []Event{labeled, tc.other})
+
+			if v := data.LabelValue("team"); v != "" {
+				t.Errorf("LabelValue = %q, want empty: %q carries no team, so the commit is not one team's",
+					v, tc.other.Identifier.Name)
+			}
+		})
+	}
+}
+
+// A DELETE carries no object and therefore no labels, so a commit holding one cannot claim a team
+// either: the deleted resource's team is not something the window still knows.
+func TestLiveCommitMessageData_LabelValue_DeleteLeavesTheCommitUnnamed(t *testing.T) {
+	deleted := labeledDeploymentEvent("gone", "prod", map[string]string{"team": "payments"})
+	deleted.Object = nil
+	deleted.Operation = "DELETE"
+
+	data := buildLiveCommitMessageData("someone", "target", []Event{
+		labeledDeploymentEvent("api", "prod", map[string]string{"team": "payments"}),
+		deleted,
+	})
+
+	if v := data.LabelValue("team"); v != "" {
+		t.Errorf("LabelValue = %q, want empty: a DELETE carries no labels to agree with", v)
+	}
+}
+
+// The accessor still answers for an empty window rather than panicking on Resources[0].
+func TestLiveCommitMessageData_LabelValue_NoResources(t *testing.T) {
+	if v := (LiveCommitMessageData{}).LabelValue("team"); v != "" {
+		t.Errorf("LabelValue = %q, want empty when the commit holds no resources", v)
+	}
+}
+
 func TestRenderLiveCommitMessage_ReadsMetadataFields(t *testing.T) {
 	config := CommitConfig{Message: CommitMessageConfig{
 		LiveTemplate: `chore: sync {{.Count}} resources{{with .LabelValue "team"}} for {{.}}{{end}}` + "\n" +

--- a/internal/git/commit_metadata_fields_test.go
+++ b/internal/git/commit_metadata_fields_test.go
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package git
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/ConfigButler/gitops-reverser/internal/types"
+)
+
+// labeledDeploymentEvent is one live event whose object carries the metadata a commit template
+// can now read: the kind, and labels.
+func labeledDeploymentEvent(name, namespace string, labels map[string]string) Event {
+	asAny := make(map[string]any, len(labels))
+	for k, v := range labels {
+		asAny[k] = v
+	}
+	return Event{
+		Object: &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]any{
+				"name": name, "namespace": namespace, "labels": asAny,
+			},
+		}},
+		Identifier: types.NewResourceIdentifier("apps", "v1", "deployments", namespace, name),
+		Operation:  "CREATE",
+	}
+}
+
+func TestBuildLiveCommitMessageData_CarriesKindAndLabels(t *testing.T) {
+	data := buildLiveCommitMessageData("someone", "target", []Event{
+		labeledDeploymentEvent("api", "prod", map[string]string{"team": "payments"}),
+	})
+
+	ref := data.Resources[0]
+	if ref.Kind != "Deployment" {
+		t.Errorf("Kind = %q, want the object's kind", ref.Kind)
+	}
+	if ref.Namespace != "prod" {
+		t.Errorf("Namespace = %q, want the namespace for a namespaced resource", ref.Namespace)
+	}
+	if got := ref.Label("team"); got != "payments" {
+		t.Errorf("Label(team) = %q, want payments", got)
+	}
+	if got := ref.Label("absent"); got != "" {
+		t.Errorf("Label(absent) = %q, want the empty string rather than an error", got)
+	}
+}
+
+// A cluster-scoped resource renders the same scope sentinel a path does, so a template need not
+// guard an empty namespace by hand.
+func TestBuildLiveCommitMessageData_ClusterScopedRendersTheSentinel(t *testing.T) {
+	event := labeledDeploymentEvent("admin", "", nil)
+	event.Identifier = types.NewResourceIdentifier("rbac.authorization.k8s.io", "v1", "clusterroles", "", "admin")
+
+	data := buildLiveCommitMessageData("someone", "target", []Event{event})
+
+	if got := data.Resources[0].Namespace; got != types.ClusterScopeSegment {
+		t.Errorf("Namespace = %q, want the %q sentinel, so a template need not guard it",
+			got, types.ClusterScopeSegment)
+	}
+}
+
+// A DELETE carries no object in production (the resource is gone), so the metadata fields are
+// empty rather than guessed. A template reading them must still render.
+func TestBuildLiveCommitMessageData_DeleteHasNoObjectMetadata(t *testing.T) {
+	event := labeledDeploymentEvent("api", "prod", map[string]string{"team": "payments"})
+	event.Object = nil
+	event.Operation = "DELETE"
+
+	ref := buildLiveCommitMessageData("someone", "target", []Event{event}).Resources[0]
+
+	if ref.Kind != "" || ref.Labels != nil {
+		t.Errorf("Kind = %q, Labels = %v, want both empty for a DELETE", ref.Kind, ref.Labels)
+	}
+	if ref.Name != "api" || ref.Namespace != "prod" {
+		t.Errorf("identity fields must survive a DELETE, got %+v", ref)
+	}
+}
+
+// A commit is 1:n, so a label is a SET here where placement reads a single value.
+func TestLiveCommitMessageData_LabelValues(t *testing.T) {
+	data := buildLiveCommitMessageData("someone", "target", []Event{
+		labeledDeploymentEvent("api", "prod", map[string]string{"team": "payments"}),
+		labeledDeploymentEvent("web", "prod", map[string]string{"team": "storefront"}),
+		labeledDeploymentEvent("cache", "prod", map[string]string{"team": "payments"}),
+		labeledDeploymentEvent("bare", "prod", nil),
+		labeledDeploymentEvent("blank", "prod", map[string]string{"team": ""}),
+	})
+
+	got := data.LabelValues("team")
+	want := []string{"payments", "storefront"}
+	if len(got) != len(want) {
+		t.Fatalf("LabelValues = %v, want %v (distinct, sorted, no blanks)", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("LabelValues = %v, want %v", got, want)
+		}
+	}
+	if v := data.LabelValue("team"); v != "" {
+		t.Errorf("LabelValue = %q, want empty when the commit spans more than one team", v)
+	}
+	if v := data.LabelValue("absent"); v != "" {
+		t.Errorf("LabelValue(absent) = %q, want empty", v)
+	}
+}
+
+// The subject-line case: one shared value names the whole commit.
+func TestLiveCommitMessageData_LabelValue_AgreedValue(t *testing.T) {
+	data := buildLiveCommitMessageData("someone", "target", []Event{
+		labeledDeploymentEvent("api", "prod", map[string]string{"team": "payments"}),
+		labeledDeploymentEvent("cache", "prod", map[string]string{"team": "payments"}),
+	})
+
+	if v := data.LabelValue("team"); v != "payments" {
+		t.Errorf("LabelValue = %q, want payments", v)
+	}
+}
+
+func TestRenderLiveCommitMessage_ReadsMetadataFields(t *testing.T) {
+	config := CommitConfig{Message: CommitMessageConfig{
+		LiveTemplate: `chore: sync {{.Count}} resources{{with .LabelValue "team"}} for {{.}}{{end}}` + "\n" +
+			`{{range .Resources}}- {{.Kind}} {{.Namespace}}/{{.Name}}` +
+			` ({{.Label "app.kubernetes.io/instance"}})` + "\n" + `{{end}}`,
+	}}
+	write := PendingWrite{Kind: PendingWriteCommit, Events: []Event{
+		labeledDeploymentEvent("api", "prod", map[string]string{
+			"team": "payments", "app.kubernetes.io/instance": "voter",
+		}),
+	}}
+
+	got, err := renderLiveCommitMessage(write, config)
+	if err != nil {
+		t.Fatalf("renderLiveCommitMessage: %v", err)
+	}
+	for _, want := range []string{"for payments", "- Deployment prod/api (voter)"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("message %q is missing %q", got, want)
+		}
+	}
+}
+
+// The accessor is the documented spelling because the raw map is a trap: these templates render
+// with missingkey=error, so indexing a label a resource does not carry fails the render, and a
+// failed render fails the commit. The admission validator must catch that, not production.
+func TestValidateCommitConfig_RejectsRawLabelIndexingAndAcceptsTheAccessor(t *testing.T) {
+	trap := CommitConfig{Message: CommitMessageConfig{
+		LiveTemplate:      `chore: {{range .Resources}}{{.Labels.team}}{{end}}`,
+		ReconcileTemplate: DefaultReconcileCommitMessageTemplate,
+	}}
+	if err := ValidateCommitConfig(trap); err == nil {
+		t.Error("a template indexing .Labels directly must be rejected: it fails for an unlabeled resource")
+	}
+
+	safe := CommitConfig{Message: CommitMessageConfig{
+		LiveTemplate: `chore: sync {{.Count}}{{range .Resources}} {{.Kind}}/{{.Namespace}}` +
+			`/{{.Name}}{{.Label "team"}}{{end}}`,
+		ReconcileTemplate: DefaultReconcileCommitMessageTemplate,
+	}}
+	if err := ValidateCommitConfig(safe); err != nil {
+		t.Errorf("the accessor form must validate: %v", err)
+	}
+}

--- a/internal/git/commit_test.go
+++ b/internal/git/commit_test.go
@@ -122,11 +122,12 @@ func TestRenderReconcileCommitMessageFromEvents_DefaultTemplate(t *testing.T) {
 
 func TestRenderReconcileCommitMessage_DefaultTemplateNamesScopedTypeAndRevision(t *testing.T) {
 	cases := []struct {
-		name     string
-		count    int
-		gvr      schema.GroupVersionResource
-		revision string
-		expected string
+		name      string
+		count     int
+		gvr       schema.GroupVersionResource
+		namespace string
+		revision  string
+		expected  string
 	}{
 		{
 			name:     "core type names the plural resource and revision",
@@ -153,10 +154,29 @@ func TestRenderReconcileCommitMessage_DefaultTemplateNamesScopedTypeAndRevision(
 			revision: "",
 			expected: "chore: reconcile 0 secrets",
 		},
+		// A namespace-scoped reconcile covers exactly one namespace by construction, so naming it
+		// is what separates the two subjects a target watching one type in two namespaces writes.
+		{
+			name:      "a namespace-scoped reconcile names its namespace",
+			count:     4,
+			gvr:       schema.GroupVersionResource{Version: "v1", Resource: "configmaps"},
+			namespace: "team-a",
+			revision:  "1331",
+			expected:  "chore: reconcile 4 configmaps in team-a (last resourceVersion: 1331)",
+		},
+		// Empty means the run was not namespace-scoped, which covers both an all-namespaces sweep
+		// and a cluster-scoped type. No word is true of both, so the subject names none.
+		{
+			name:     "an unscoped reconcile says nothing about namespaces",
+			count:    9,
+			gvr:      schema.GroupVersionResource{Version: "v1", Resource: "configmaps"},
+			revision: "1400",
+			expected: "chore: reconcile 9 configmaps (last resourceVersion: 1400)",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			scope := ResyncScopeFor(tc.gvr, "")
+			scope := ResyncScopeFor(tc.gvr, tc.namespace)
 			message, err := renderReconcileCommitMessage(
 				tc.count, "demo", &scope, tc.revision, ResolveCommitConfig(nil))
 			require.NoError(t, err)

--- a/internal/git/commit_test.go
+++ b/internal/git/commit_test.go
@@ -671,10 +671,12 @@ func renderSingleLiveCommitMessage(event Event, config CommitConfig) (string, er
 // expectSingleLiveMessage builds the message the default live template renders for one retained
 // resource: a "chore: sync 1 resource" subject and one body line per entry.
 func expectSingleLiveMessage(operation, apiVersion, resource, namespace, name string) string {
-	location := name
-	if namespace != "" {
-		location = namespace + "/" + name
+	// The namespace position is never blank: a cluster-scoped resource renders the "_cluster"
+	// sentinel, the same word its Git path uses, so the default template prints it unguarded.
+	if namespace == "" {
+		namespace = types.ClusterScopeSegment
 	}
+	location := namespace + "/" + name
 
 	return fmt.Sprintf("chore: sync 1 resource\n\n- [%s] %s/%s/%s\n", operation, apiVersion, resource, location)
 }

--- a/internal/git/open_window.go
+++ b/internal/git/open_window.go
@@ -108,14 +108,24 @@ func buildLiveCommitMessageData(author, gitTarget string, events []Event) LiveCo
 	resources := make([]ResourceRef, 0, len(events))
 	for _, e := range events {
 		operations[e.Operation]++
+		// Kind and Labels live on the object, which a DELETE event does not carry (the object
+		// is gone by then), so both stay empty for one rather than being guessed at.
+		kind := ""
+		var labels map[string]string
+		if e.Object != nil {
+			kind = e.Object.GetKind()
+			labels = e.Object.GetLabels()
+		}
 		resources = append(resources, ResourceRef{
 			Operation:  e.Operation,
 			APIVersion: buildAPIVersion(e.Identifier.Group, e.Identifier.Version),
 			Group:      e.Identifier.Group,
 			Version:    e.Identifier.Version,
 			Resource:   e.Identifier.Resource,
-			Namespace:  e.Identifier.Namespace,
+			Kind:       kind,
+			Namespace:  e.Identifier.NamespaceOrCluster(),
 			Name:       e.Identifier.Name,
+			Labels:     labels,
 		})
 	}
 	return LiveCommitMessageData{

--- a/internal/git/placement_label_test.go
+++ b/internal/git/placement_label_test.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package git
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ConfigButler/gitops-reverser/internal/manifestanalyzer"
+)
+
+// labeledConfigMapEvent is newConfigMapEvent with metadata.labels set on the LIVE object —
+// the only place a "{label:key}" template can read them from, since placement runs precisely
+// when the resource has no document in Git.
+func labeledConfigMapEvent(name, namespace string, labels map[string]string) Event {
+	event := newConfigMapEvent(name, namespace)
+	meta, _ := event.Object.Object["metadata"].(map[string]interface{})
+	asAny := make(map[string]interface{}, len(labels))
+	for k, v := range labels {
+		asAny[k] = v
+	}
+	meta["labels"] = asAny
+	return event
+}
+
+func targetedLabeledConfigMapEvent(name, namespace string, labels map[string]string) Event {
+	event := labeledConfigMapEvent(name, namespace, labels)
+	event.GitTargetName = metricsTestGitTargetName
+	event.GitTargetNamespace = metricsTestGitTargetNamespace
+	return event
+}
+
+// The write path's half of the feature: the label has to survive the trip from the live object
+// into PlacementRequest, which is the one wiring a unit test of the analyzer cannot prove.
+func TestPlacement_LabelTemplate_ReadsTheLiveObjectsLabels(t *testing.T) {
+	worktree := newWorktreeForTest(t)
+	root := worktree.Filesystem().Root()
+	policy := &manifestanalyzer.PlacementPolicy{
+		ByType: map[string]string{"v1/configmaps": "{label:app.kubernetes.io/instance}/configmaps.yaml"},
+	}
+
+	changed := applyEventsWithPolicy(t, worktree, policy,
+		labeledConfigMapEvent("cache", "app", map[string]string{"app.kubernetes.io/instance": "voter"}))
+	require.True(t, changed)
+
+	got, err := os.ReadFile(filepath.Join(root, "voter", "configmaps.yaml"))
+	require.NoError(t, err, "the new file must land under the label's value")
+	assert.Contains(t, string(got), "name: cache")
+}
+
+// Two resources sharing a label value bundle into one file, exactly as any other bundling
+// template does — that grouping is the whole reason to place by label.
+func TestPlacement_LabelTemplate_BundlesResourcesSharingAValue(t *testing.T) {
+	worktree := newWorktreeForTest(t)
+	root := worktree.Filesystem().Root()
+	policy := &manifestanalyzer.PlacementPolicy{
+		ByType: map[string]string{"v1/configmaps": "{label:round}/submissions.yaml"},
+	}
+
+	applyEventsWithPolicy(t, worktree, policy,
+		labeledConfigMapEvent("first", "app", map[string]string{"round": "r7"}))
+	applyEventsWithPolicy(t, worktree, policy,
+		labeledConfigMapEvent("second", "app", map[string]string{"round": "r7"}))
+
+	got, err := os.ReadFile(filepath.Join(root, "r7", "submissions.yaml"))
+	require.NoError(t, err)
+	assert.Contains(t, string(got), "name: first")
+	assert.Contains(t, string(got), "name: second")
+}
+
+// A resource missing the label still lands in the mirror, at the built-in "_unlabeled" sentinel,
+// rather than being silently absent until somebody labels it.
+func TestPlacement_MissingLabel_WritesToTheUnlabeledSentinel(t *testing.T) {
+	worktree := newWorktreeForTest(t)
+	root := worktree.Filesystem().Root()
+	policy := &manifestanalyzer.PlacementPolicy{
+		ByType: map[string]string{"v1/configmaps": "{label:round}/submissions.yaml"},
+	}
+
+	changed := applyEventsWithPolicy(t, worktree, policy,
+		targetedLabeledConfigMapEvent("cache", "app", nil))
+	require.True(t, changed)
+
+	got, err := os.ReadFile(filepath.Join(root, "_unlabeled", "submissions.yaml"))
+	require.NoError(t, err, "an unlabeled resource must still be placed, at the sentinel bucket")
+	assert.Contains(t, string(got), "name: cache")
+}
+
+// A later label does not move the file already written: placement is match-first and create-time
+// only, so a resource labeled after the fact keeps living at the sentinel path it first resolved.
+func TestPlacement_MissingLabel_LaterLabelDoesNotMoveTheFile(t *testing.T) {
+	worktree := newWorktreeForTest(t)
+	root := worktree.Filesystem().Root()
+	policy := &manifestanalyzer.PlacementPolicy{
+		ByType: map[string]string{"v1/configmaps": "{label:round}/submissions.yaml"},
+	}
+
+	applyEventsWithPolicy(t, worktree, policy, labeledConfigMapEvent("cache", "app", nil))
+	applyEventsWithPolicy(t, worktree, policy,
+		labeledConfigMapEvent("cache", "app", map[string]string{"round": "r7"}))
+
+	got, err := os.ReadFile(filepath.Join(root, "_unlabeled", "submissions.yaml"))
+	require.NoError(t, err, "the document is match-first: it stays where it was first placed")
+	assert.Contains(t, string(got), "name: cache")
+
+	_, statErr := os.Stat(filepath.Join(root, "r7", "submissions.yaml"))
+	assert.True(t, os.IsNotExist(statErr), "a later label must not create or move to a new file")
+}

--- a/internal/git/plan_flush.go
+++ b/internal/git/plan_flush.go
@@ -388,8 +388,18 @@ func wroteBytes(o upsertOutcome) bool {
 // file) is logged and left unwritten rather than mis-written; the next event or resync retries.
 func (wb *writeBatch) createNew(ctx context.Context, event Event) (upsertOutcome, error) {
 	kind := ""
+	// Labels come off the event's object — the SANITIZED one (see Event.Object), and the only
+	// place they exist at this point: placement runs precisely when there is no document in Git
+	// to read them from. Sanitized is also what the "{label:key}" variable must see, and what the
+	// GitTarget's Validated gate assumes: a label the writer strips is already absent here, so a
+	// template naming one is refused at the gate rather than quietly bucketing every resource of
+	// its type together. An object-less event cannot reach this function (a field patch branches
+	// off in applyEvent, and a non-delete always carries an object), but if one ever did, nil
+	// labels place it at the unlabeled sentinel rather than guess.
+	var labels map[string]string
 	if event.Object != nil {
 		kind = event.Object.GetKind()
+		labels = event.Object.GetLabels()
 	}
 	// A folder covering several render roots has no single one for a NEW document, and picking
 	// one would hand it to an environment nobody named. An existing document is unaffected: it
@@ -408,6 +418,7 @@ func (wb *writeBatch) createNew(ctx context.Context, event Event) (upsertOutcome
 		Kind:       kind,
 		Sensitive:  sensitive,
 		WriteScope: wb.writeSubdir,
+		Labels:     labels,
 	})
 	if err != nil {
 		refusal := placementRefusalReason(err)

--- a/internal/git/types.go
+++ b/internal/git/types.go
@@ -88,13 +88,23 @@ const (
 	DefaultCommitterName = "GitOps Reverser"
 	// DefaultCommitterEmail matches the default operator email in Git history.
 	DefaultCommitterEmail = "noreply@configbutler.ai"
-	// DefaultReconcileCommitMessageTemplate names the synced type, so the otherwise
-	// indistinguishable per-type reconciles one GitTarget produces are self-describing. Plural
-	// resource alone for readability; add {{.APIVersion}} when plural collisions matter. The
-	// {{if}} guards fall back to "chore: reconcile N resources" for a whole-target reconcile, so
-	// the subject never degrades to an identity-less "chore: reconcile N ".
+	// DefaultReconcileCommitMessageTemplate names the synced type AND, when the run covered one,
+	// the namespace, so the otherwise indistinguishable per-cell reconciles one GitTarget
+	// produces are self-describing: a target watching configmaps in team-a and in team-b would
+	// otherwise write two byte-identical subjects. Plural resource alone for readability; add
+	// {{.APIVersion}} when plural collisions matter.
+	//
+	// The {{if}} guards fall back to "chore: reconcile N resources" for a whole-target reconcile,
+	// so the subject never degrades to an identity-less "chore: reconcile N ". The namespace guard
+	// in particular must stay an {{if}} rather than a sentinel: an empty Namespace here means the
+	// run was not namespace-scoped, which covers BOTH an all-namespaces sweep of a namespaced type
+	// and a cluster-scoped type having no namespaces at all. No single word is true of both, so
+	// the honest rendering of "no namespace to name" is to say nothing. (Contrast ResourceRef,
+	// which describes ONE resource, where empty has exactly one meaning and carries the
+	// types.ClusterScopeSegment sentinel.)
 	DefaultReconcileCommitMessageTemplate = "chore: reconcile {{.Count}} " +
 		"{{if .Resource}}{{.Resource}}{{else}}resources{{end}}" +
+		"{{if .Namespace}} in {{.Namespace}}{{end}}" +
 		"{{if .Revision}} (last resourceVersion: {{.Revision}}){{end}}"
 	// DefaultLiveCommitMessageTemplate describes retained input resources.
 	DefaultLiveCommitMessageTemplate = "chore: sync {{.Count}} resource{{if ne .Count 1}}s{{end}}\n\n" +

--- a/internal/git/types.go
+++ b/internal/git/types.go
@@ -719,16 +719,28 @@ func (d LiveCommitMessageData) LabelValues(key string) []string {
 	return values
 }
 
-// LabelValue is the one value every resource in this commit agrees on for key, and "" when
-// they disagree or none of them carries the label. It is what a SUBJECT line wants: naming
-// the team a commit belongs to is only honest when the commit is one team's.
+// LabelValue is the one value every resource in this commit agrees on for key, and "" unless
+// all of them carry it with that value. It is what a SUBJECT line wants: naming the team a
+// commit belongs to is only honest when the commit is one team's.
 //
 //	chore: sync {{.Count}} resources{{with .LabelValue "team"}} for {{.}}{{end}}
+//
+// A resource that does not carry the label DISAGREES; it does not abstain. That is why this
+// cannot be LabelValues with a length check: that set skips the unlabeled, so one
+// "team: payments" resource committed next to an unlabeled one would name the whole commit
+// "for payments" and hide the resource nobody can attribute. The same rule leaves a commit
+// containing a DELETE unnamed, since a DELETE carries no object and so no labels (see
+// ResourceRef.Labels) — the deleted resource's team is not something the window can know.
 func (d LiveCommitMessageData) LabelValue(key string) string {
-	if values := d.LabelValues(key); len(values) == 1 {
-		return values[0]
+	shared := ""
+	for _, r := range d.Resources {
+		value := r.Label(key)
+		if value == "" || (shared != "" && value != shared) {
+			return ""
+		}
+		shared = value
 	}
-	return ""
+	return shared
 }
 
 // ResolveCommitConfig resolves a GitProvider's commit settings into runtime defaults.

--- a/internal/git/types.go
+++ b/internal/git/types.go
@@ -4,6 +4,7 @@ package git
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	gogit "github.com/go-git/go-git/v6"
@@ -98,7 +99,7 @@ const (
 	// DefaultLiveCommitMessageTemplate describes retained input resources.
 	DefaultLiveCommitMessageTemplate = "chore: sync {{.Count}} resource{{if ne .Count 1}}s{{end}}\n\n" +
 		"{{range .Resources -}}" +
-		"- [{{.Operation}}] {{.APIVersion}}/{{.Resource}}/{{if .Namespace}}{{.Namespace}}/{{end}}{{.Name}}\n" +
+		"- [{{.Operation}}] {{.APIVersion}}/{{.Resource}}/{{.Namespace}}/{{.Name}}\n" +
 		"{{end -}}"
 
 	resourceRefStringPartCap = 5
@@ -600,19 +601,50 @@ type ReconcileCommitMessageData struct {
 
 // ResourceRef is the lightweight resource identifier emitted to grouped commit
 // templates via LiveCommitMessageData.Resources.
+//
+// Its fields are deliberately the placement template language's variables under Go template
+// casing: {namespace} is .Namespace, {kind} is .Kind, and so on.
+// The two renderers are separate on purpose (a path must be statically checkable, a message
+// must be able to range over n resources), but a reader should not have to learn two
+// vocabularies to describe the same resource. See docs/configuration.md.
 type ResourceRef struct {
 	Operation  string
 	APIVersion string
 	Group      string
 	Version    string
 	Resource   string
-	Namespace  string
-	Name       string
+	// Kind is the manifest kind, the commit-message spelling of the {kind} placement
+	// variable. It is read off the event's object, so it is EMPTY for a DELETE: the watcher
+	// carries no object for one, because by then the object is gone from the cluster.
+	Kind string
+	// Namespace is the resource's namespace, or the literal "_cluster" when it is
+	// cluster-scoped — types.ClusterScopeSegment, the same word the canonical Git path and the
+	// {namespace} placement variable use. A cluster-scoped resource HAS a scope name; it is
+	// simply not a namespace, and "_cluster" is a name no real namespace can collide with
+	// (DNS-1123 forbids "_"). A template therefore never has to guard this field.
+	Namespace string
+	Name      string
+	// Labels is the resource's metadata.labels as the writer commits them: the SANITIZED
+	// object's labels, so one internal/sanitize strips is already absent, exactly as for the
+	// "{label:key}" placement variable. It is nil for a DELETE (no object) and for a resource
+	// carrying none.
+	//
+	// Read it with .Label, not with .Labels.key — see Label.
+	Labels map[string]string
 }
 
-// String renders the ref as group/version/resource[/namespace]/name.
-// The format mirrors ResourceIdentifier.String for templates that want to
-// {{range}} over Resources and just print each entry.
+// Label is the value of one label on this resource, and "" when it does not carry the label.
+//
+// Use it rather than indexing Labels directly. These templates render with
+// missingkey=error, so "{{.Labels.team}}" does not render empty for a resource that has no
+// "team" label: it fails the render, and a failed render fails the whole commit (the window's
+// events are lost until the next resync). "{{.Label \"team\"}}" renders empty instead, which
+// is this language's counterpart of the "_unlabeled" bucket a path falls back to.
+func (r ResourceRef) Label(key string) string { return r.Labels[key] }
+
+// String renders the ref as group/version/resource/namespace/name, where the namespace segment
+// is "_cluster" for a cluster-scoped resource (Namespace never renders blank). Templates that
+// {{range}} over Resources and print each entry get that form.
 func (r ResourceRef) String() string {
 	parts := make([]string, 0, resourceRefStringPartCap)
 	if r.Group != "" {
@@ -648,6 +680,45 @@ type LiveCommitMessageData struct {
 	// Resources is the per-resource list, deduplicated by file path so the
 	// final state is what's being committed.
 	Resources []ResourceRef
+}
+
+// LabelValues is the sorted, distinct set of values this commit's resources carry for one
+// label key, skipping every resource that does not set it (so the result is empty, never a
+// list with a blank in it).
+//
+// A label is single-valued for a path and set-valued for a commit message: placement asks the
+// question of one resource, a commit asks it of the n resources in the window. Printing the
+// slice renders Go's "[a b]" form, so a template usually ranges over it:
+//
+//	{{range .LabelValues "team"}}{{.}} {{end}}
+func (d LiveCommitMessageData) LabelValues(key string) []string {
+	seen := make(map[string]struct{}, len(d.Resources))
+	values := make([]string, 0, len(d.Resources))
+	for _, r := range d.Resources {
+		value := r.Labels[key]
+		if value == "" {
+			continue
+		}
+		if _, dup := seen[value]; dup {
+			continue
+		}
+		seen[value] = struct{}{}
+		values = append(values, value)
+	}
+	sort.Strings(values)
+	return values
+}
+
+// LabelValue is the one value every resource in this commit agrees on for key, and "" when
+// they disagree or none of them carries the label. It is what a SUBJECT line wants: naming
+// the team a commit belongs to is only honest when the commit is one team's.
+//
+//	chore: sync {{.Count}} resources{{with .LabelValue "team"}} for {{.}}{{end}}
+func (d LiveCommitMessageData) LabelValue(key string) string {
+	if values := d.LabelValues(key); len(values) == 1 {
+		return values[0]
+	}
+	return ""
 }
 
 // ResolveCommitConfig resolves a GitProvider's commit settings into runtime defaults.

--- a/internal/manifestanalyzer/placement.go
+++ b/internal/manifestanalyzer/placement.go
@@ -9,6 +9,8 @@ import (
 	"regexp"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/util/validation"
+
 	"github.com/ConfigButler/gitops-reverser/internal/types"
 )
 
@@ -43,6 +45,19 @@ type PlacementRequest struct {
 	// rebased under WriteScope rather than escaping it. Empty for a self-contained subtree,
 	// where the scan root IS spec.path and every resolved path is already in scope.
 	WriteScope string
+	// Labels is metadata.labels as the writer will commit them — the SANITIZED object's labels,
+	// not the raw cluster object's, so one internal/sanitize strips (kustomize.toolkit.fluxcd.io/*,
+	// kro.run/*, applyset.kubernetes.io/*) is already gone by the time it gets here. That is why
+	// the GitTarget's Validated gate refuses a template reading one of those: it could never
+	// discriminate by it. Nil for a resource carrying no labels.
+	//
+	// A key the resource does not set — or sets to the empty string, which Kubernetes allows —
+	// renders the "{label:key|fallback}" fallback the template declared, and the built-in
+	// placementUnlabeledSentinel when it declared none. Either way the resource is placed: the
+	// DEFAULT never renders an empty segment, because that would fold every unlabeled resource
+	// of the type one directory up. A template can still ask for exactly that fold, by declaring
+	// an empty fallback ("{label:key|}").
+	Labels map[string]string
 }
 
 // PlacementSource names which mechanism produced a Path: the "why here" answer for one document.
@@ -167,6 +182,12 @@ func (e *PlacementRefusedError) Unwrap() error { return e.cause }
 func LocateNew(store *ManifestStore, policy *PlacementPolicy, req PlacementRequest) (PlacementResult, error) {
 	vars := placementVars(req)
 
+	// A declared template can only fail to render because its own TEXT is wrong — an unknown
+	// variable. The Validated gate rejects those before any write, so reaching one here means
+	// the spec is ahead of the gate; fall through below rather than erroring mid-batch.
+	// "{label:key}" never fails to render: a resource that does not carry the label gets the
+	// "{label:key|fallback}" value, or the built-in unlabeled sentinel if the template named
+	// none (see placementUnlabeledSentinel).
 	if path, source, ok, err := resolveDeclared(policy, req, vars); err == nil && ok {
 		return finishPlacement(store, req, path, source)
 	}
@@ -465,12 +486,113 @@ func PlacementTypeKey(group, version, resource string) string {
 	return fmt.Sprintf("%s/%s/%s", group, version, resource)
 }
 
-var placementVariablePattern = regexp.MustCompile(`\{[a-zA-Z]+\}`)
+// placementPlaceholderPattern matches anything "{...}"-shaped rather than only a legal variable
+// name, so a placeholder this package does not understand is REPORTED instead of left in the path
+// as literal text. That widening is what makes "{label:key}" safe to add: a label key may contain
+// "/", so an unrecognized label placeholder pasted through verbatim would split into directories.
+var placementPlaceholderPattern = regexp.MustCompile(`\{[^{}]*\}`)
+
+// placementLabelPrefix introduces the one variable that takes an argument:
+// "{label:app.kubernetes.io/instance}" renders that label's value on the placed resource.
+const placementLabelPrefix = "label:"
+
+// placementLabelFallbackSeparator introduces the optional value to use when the resource does
+// not carry the label: "{label:team|unassigned}". "|" is not legal in a label key, so it cannot
+// be mistaken for part of one, and a "|" with nothing after it is a declared EMPTY fallback
+// rather than a typo (see validPlacementFallback).
+const placementLabelFallbackSeparator = "|"
+
+// placementUnlabeledSentinel is what "{label:key}" renders for a resource that does not carry
+// the label (or carries it empty) when the template names no explicit "{label:key|fallback}".
+//
+// It plays the same role here that "_cluster" plays for {namespaceOrCluster}: a value no real
+// label could ever hold — a label value must be alphanumeric at both ends, and this starts with
+// "_" — so it can never collide with one, and it is a single documented constant rather than a
+// per-deployment invisible default. A template that wants its own bucket name still writes
+// "{label:key|fallback}"; this is only what renders when it doesn't, so every resource is still
+// placed and the mirror never has a silent, label-shaped gap in it.
+const placementUnlabeledSentinel = "_unlabeled"
+
+// placementLabelVariable is a parsed "{label:key}" or "{label:key|fallback}" placeholder. Either
+// form always renders: a resource missing the label gets the declared fallback if the template
+// names one, or placementUnlabeledSentinel otherwise. The explicit form exists to let the author
+// choose their own bucket — a different name, or no segment at all — in place of the built-in
+// one; it is not how a template opts in to being placed at all.
+type placementLabelVariable struct {
+	key         string
+	fallback    string
+	hasFallback bool
+}
+
+// parsePlacementLabelVariable splits a placeholder's inner name into a label key and its optional
+// fallback. The second result is false for a name that is not a label variable at all.
+func parsePlacementLabelVariable(name string) (placementLabelVariable, bool) {
+	spec, isLabel := strings.CutPrefix(name, placementLabelPrefix)
+	if !isLabel {
+		return placementLabelVariable{}, false
+	}
+	if key, fallback, found := strings.Cut(spec, placementLabelFallbackSeparator); found {
+		return placementLabelVariable{key: key, fallback: fallback, hasFallback: true}, true
+	}
+	return placementLabelVariable{key: spec}, true
+}
+
+// valid reports whether the key is one Kubernetes would accept and the declared fallback, if
+// there is one, is safe as a rendered path segment.
+func (v placementLabelVariable) valid() bool {
+	if len(validation.IsQualifiedName(v.key)) != 0 {
+		return false
+	}
+	if !v.hasFallback {
+		return true
+	}
+	return validPlacementFallback(v.fallback)
+}
+
+// placementFallbackPattern is the charset a declared "{label:key|fallback}" bucket may use: the
+// label-VALUE charset, minus the label rule that both ends be alphanumeric.
+//
+// Dropping that end rule is the point rather than an oversight. A fallback that is itself a legal
+// label value shares its bucket with resources genuinely labeled it — "{label:team|unassigned}"
+// puts the unlabeled ones exactly where team=unassigned goes, which is sometimes wanted and
+// sometimes a surprise. Allowing a leading "_" lets a template say "{label:team|_none}" and get a
+// bucket no real value can reach, the same collision-proofing placementUnlabeledSentinel and
+// "_cluster" are built on. What the charset keeps is the half that protects the path: no "/", no
+// "\", no "%", no space, no control character, so a fallback can no more invent a directory or
+// escape the write jail than a real label value can.
+var placementFallbackPattern = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+
+// placementFallbackMaxLength is the length limit Kubernetes puts on a label VALUE. A fallback
+// stands in for one, so it is held to the same ceiling rather than being allowed to grow into a
+// path segment no label could have produced.
+const placementFallbackMaxLength = 63
+
+// validPlacementFallback reports whether a declared fallback is safe as one rendered path segment.
+//
+// The EMPTY fallback ("{label:key|}") is deliberately accepted, and renders nothing:
+// collapseEmptyPathSegments then drops the segment, so an unlabeled resource lands one directory
+// up instead of in a bucket of its own. That is the same fold placementUnlabeledSentinel exists to
+// prevent — but the sentinel protects the DEFAULT, the case where nobody chose. A template that
+// spells out an empty fallback has chosen, in text a reviewer can see in the GitTarget, so it is
+// honoured rather than second-guessed. The fence that actually matters still holds either way:
+// "." and ".." are refused outright and the charset refuses a separator, so the worst an author
+// can do to themselves here is a flatter tree.
+func validPlacementFallback(v string) bool {
+	if v == "" {
+		return true
+	}
+	if len(v) > placementFallbackMaxLength || v == "." || v == ".." {
+		return false
+	}
+	return placementFallbackPattern.MatchString(v)
+}
 
 // isKnownPlacementVariable reports whether name is one of the variables
-// RenderPlacementTemplate accepts. Keep in sync with placementVars and
-// placementVariableNames.
+// RenderPlacementTemplate accepts. Keep in sync with placementVars.
 func isKnownPlacementVariable(name string) bool {
+	if label, isLabel := parsePlacementLabelVariable(name); isLabel {
+		return label.valid()
+	}
 	switch name {
 	case "group", "groupPath", "version", "apiVersion", "resource",
 		"kind", "scope", "namespace", "namespaceOrCluster", "name", "sensitiveSuffix":
@@ -480,14 +602,15 @@ func isKnownPlacementVariable(name string) bool {
 	}
 }
 
-// placementVariableNames lists every variable isKnownPlacementVariable accepts,
-// for callers (ValidPlacementTemplateSyntax) that need the full set rather than a
-// single-name membership check.
-func placementVariableNames() []string {
-	return []string{
-		"group", "groupPath", "version", "apiVersion", "resource",
-		"kind", "scope", "namespace", "namespaceOrCluster", "name", "sensitiveSuffix",
-	}
+// unknownPlacementVariablesError names every placeholder in tmpl that is not a variable this
+// package renders, shared by the render path and the static Validated gate so the two report a
+// typo identically.
+func unknownPlacementVariablesError(tmpl string, unknown []string) error {
+	return fmt.Errorf(
+		"placement template %q references unknown variable(s): %s",
+		tmpl,
+		strings.Join(unknown, ", "),
+	)
 }
 
 func placementVars(req PlacementRequest) map[string]string {
@@ -511,7 +634,7 @@ func placementVars(req PlacementRequest) map[string]string {
 	if req.Sensitive {
 		sensitiveSuffix = ".sops.yaml"
 	}
-	return map[string]string{
+	vars := map[string]string{
 		"group":              id.Group,
 		"groupPath":          id.Group,
 		"version":            id.Version,
@@ -524,6 +647,12 @@ func placementVars(req PlacementRequest) map[string]string {
 		"name":               id.Name,
 		"sensitiveSuffix":    sensitiveSuffix,
 	}
+	// Labels join the same map under their full placeholder name. The "label:" prefix is not a
+	// legal bare variable, so a label literally named "namespace" cannot shadow the built-in one.
+	for key, value := range req.Labels {
+		vars[placementLabelPrefix+key] = value
+	}
+	return vars
 }
 
 // RenderPlacementTemplate expands a brace-variable path template ("{namespace}/
@@ -534,8 +663,28 @@ func placementVars(req PlacementRequest) map[string]string {
 // typo in a declared template is caught rather than silently left as literal text.
 func RenderPlacementTemplate(tmpl string, vars map[string]string) (string, error) {
 	var unknown []string
-	rendered := placementVariablePattern.ReplaceAllStringFunc(tmpl, func(match string) string {
+	rendered := placementPlaceholderPattern.ReplaceAllStringFunc(tmpl, func(match string) string {
 		name := strings.Trim(match, "{}")
+		if label, isLabel := parsePlacementLabelVariable(name); isLabel {
+			if !label.valid() {
+				unknown = append(unknown, match)
+				return match
+			}
+			// Present-but-empty counts as absent. Kubernetes accepts an empty label value, and
+			// rendering one leaves a segment collapseEmptyPathSegments then drops — folding every
+			// resource that happens to carry the label empty onto one path, which is exactly the
+			// silent identity fold sanitizePlacementSegment exists to prevent.
+			if value := vars[placementLabelPrefix+label.key]; value != "" {
+				return sanitizePlacementSegment(value)
+			}
+			// The declared fallback wins over the sentinel, including when it is empty: that is
+			// the one case where this DOES render an empty segment, because the template asked
+			// for it in writing (see validPlacementFallback).
+			if label.hasFallback {
+				return label.fallback
+			}
+			return placementUnlabeledSentinel
+		}
 		if !isKnownPlacementVariable(name) {
 			unknown = append(unknown, match)
 			return match
@@ -543,11 +692,7 @@ func RenderPlacementTemplate(tmpl string, vars map[string]string) (string, error
 		return sanitizePlacementSegment(vars[name])
 	})
 	if len(unknown) > 0 {
-		return "", fmt.Errorf(
-			"placement template %q references unknown variable(s): %s",
-			tmpl,
-			strings.Join(unknown, ", "),
-		)
+		return "", unknownPlacementVariablesError(tmpl, unknown)
 	}
 	return collapseEmptyPathSegments(rendered), nil
 }
@@ -582,20 +727,48 @@ func collapseEmptyPathSegments(p string) string {
 // placement variables, independent of any resource identity — the check a
 // GitTarget's Validated gate runs statically at reconcile time, before any
 // repository scan.
+//
+// It scans placeholders rather than rendering the template, because "{label:key}" has no static
+// value to render: whether a resource sets that label, and so whether it renders the value or
+// falls back to a fallback/sentinel, is a per-object fact answered at write time. What IS static,
+// and checked here, is that the key itself is one Kubernetes would accept.
 func ValidPlacementTemplateSyntax(tmpl string) error {
-	names := placementVariableNames()
-	stub := make(map[string]string, len(names))
-	for _, name := range names {
-		stub[name] = ""
+	var unknown []string
+	for _, match := range placementPlaceholderPattern.FindAllString(tmpl, -1) {
+		if !isKnownPlacementVariable(strings.Trim(match, "{}")) {
+			unknown = append(unknown, match)
+		}
 	}
-	_, err := RenderPlacementTemplate(tmpl, stub)
-	return err
+	if len(unknown) > 0 {
+		return unknownPlacementVariablesError(tmpl, unknown)
+	}
+	return nil
+}
+
+// PlacementTemplateLabelKeys lists the label keys tmpl reads, in template order, so a caller with
+// knowledge this package does not have — which labels never survive to the write path — can reject
+// a template that could never discriminate by the label it names: every resource of the type would
+// render the same fallback/sentinel value, silently collapsing what looked like a per-label split
+// into one bucket. Malformed label placeholders are left out; ValidPlacementTemplateSyntax reports
+// those.
+func PlacementTemplateLabelKeys(tmpl string) []string {
+	var keys []string
+	for _, match := range placementPlaceholderPattern.FindAllString(tmpl, -1) {
+		if label, isLabel := parsePlacementLabelVariable(strings.Trim(match, "{}")); isLabel && label.valid() {
+			keys = append(keys, label.key)
+		}
+	}
+	return keys
 }
 
 // ValidPlacementTemplatePath statically rejects a template whose own literal text could render
 // outside spec.path or with the wrong file name: "..", a leading "/", a "\" separator, or a
 // non-YAML suffix. Runs at the Validated gate, before any scan, so a bad template fails fast and
 // visibly instead of skipping resource by resource.
+//
+// A "{label:key}" placeholder may itself contain the "/" of a prefixed label key, so the segment
+// walk below sees it split in two. That is harmless: neither half can be ".." (the key is a
+// qualified name), and the suffix check reads the whole string.
 func ValidPlacementTemplatePath(tmpl string) error {
 	trimmed := strings.TrimSpace(tmpl)
 	if trimmed == "" {
@@ -626,6 +799,10 @@ func ValidPlacementTemplatePath(tmpl string) error {
 // Those are {groupPath} and {resource}, deliberately NOT {version}: two served versions of one
 // group/resource are the SAME object, so a version segment splits one identity rather than
 // separating two.
+//
+// {label:key} deliberately counts for nothing here. A label is not identity — two Secrets in one
+// namespace can carry the same one — so it can only ever ADD discrimination to a path that is
+// already complete, never supply the part that is missing.
 func IdentityCompletePlacementTemplate(tmpl string, narrowedToOneType bool) bool {
 	hasName := strings.Contains(tmpl, "{name}")
 	hasScope := strings.Contains(tmpl, "{namespace}") || strings.Contains(tmpl, "{namespaceOrCluster}")

--- a/internal/manifestanalyzer/placement.go
+++ b/internal/manifestanalyzer/placement.go
@@ -86,7 +86,7 @@ const (
 	// convention: a file that root cannot reach would never render at all.
 	PlacementSourceKustomizeRoot PlacementSource = "kustomize_root"
 	// PlacementSourceCanonical is the built-in, versionless
-	// {namespaceOrCluster}/{group}/{resource}/{name}.yaml fallback: no declared
+	// {namespace}/{group}/{resource}/{name}.yaml fallback: no declared
 	// template, and no single kustomize root to hang the file off. For a repository
 	// with a hand-authored layout this is the signal that a placement.byType or
 	// placement.default line is missing — which is why it is counted per
@@ -505,7 +505,7 @@ const placementLabelFallbackSeparator = "|"
 // placementUnlabeledSentinel is what "{label:key}" renders for a resource that does not carry
 // the label (or carries it empty) when the template names no explicit "{label:key|fallback}".
 //
-// It plays the same role here that "_cluster" plays for {namespaceOrCluster}: a value no real
+// It plays the same role here that "_cluster" plays for a cluster-scoped {namespace}: a value no real
 // label could ever hold — a label value must be alphanumeric at both ends, and this starts with
 // "_" — so it can never collide with one, and it is a single documented constant rather than a
 // per-deployment invisible default. A template that wants its own bucket name still writes
@@ -595,17 +595,36 @@ func isKnownPlacementVariable(name string) bool {
 	}
 	switch name {
 	case "group", "groupPath", "version", "apiVersion", "resource",
-		"kind", "scope", "namespace", "namespaceOrCluster", "name", "sensitiveSuffix":
+		"kind", "scope", "namespace", "name", "sensitiveSuffix":
 		return true
 	default:
 		return false
 	}
 }
 
+// removedPlacementVariableGuidance is the sentence that tells the author of a REMOVED variable
+// what to write instead, and "" for a placeholder that is merely unknown. A removed name reported
+// as "unknown" reads like a typo and sends its reader hunting for a misspelling that is not there,
+// so it is named and answered.
+func removedPlacementVariableGuidance(placeholder string) string {
+	if placeholder == "{namespaceOrCluster}" {
+		return "{namespaceOrCluster} was removed: {namespace} now renders \"" +
+			types.ClusterScopeSegment + "\" for a cluster-scoped resource, so it is the only " +
+			"namespace-position variable"
+	}
+	return ""
+}
+
 // unknownPlacementVariablesError names every placeholder in tmpl that is not a variable this
 // package renders, shared by the render path and the static Validated gate so the two report a
-// typo identically.
+// typo identically. A placeholder that names a REMOVED variable is reported with its
+// replacement instead of being lumped in with the typos.
 func unknownPlacementVariablesError(tmpl string, unknown []string) error {
+	for _, placeholder := range unknown {
+		if guidance := removedPlacementVariableGuidance(placeholder); guidance != "" {
+			return fmt.Errorf("placement template %q: %s", tmpl, guidance)
+		}
+	}
 	return fmt.Errorf(
 		"placement template %q references unknown variable(s): %s",
 		tmpl,
@@ -616,15 +635,11 @@ func unknownPlacementVariablesError(tmpl string, unknown []string) error {
 func placementVars(req PlacementRequest) map[string]string {
 	id := req.Identifier
 	scope := "namespaced"
-	nsOrCluster := id.Namespace
 	if id.IsClusterScoped() {
+		// {scope} is the readable "cluster"/"namespaced" descriptor. The namespace-position
+		// VALUE is {namespace}, which renders types.ClusterScopeSegment here — the same word
+		// the canonical path and a commit message use, so all three name a scope identically.
 		scope = "cluster"
-		// The namespace-position segment uses "_cluster", an illegal Kubernetes
-		// namespace name (DNS-1123 forbids "_"), so it can never collide with a real
-		// namespace — unlike a bare "cluster", which is a legal namespace name. This
-		// mirrors ResourceIdentifier.ToGitPath's built-in canonical scope segment.
-		// {scope} above stays the readable "cluster"/"namespaced" descriptor.
-		nsOrCluster = "_cluster"
 	}
 	apiVersion := id.Version
 	if id.Group != "" {
@@ -635,17 +650,16 @@ func placementVars(req PlacementRequest) map[string]string {
 		sensitiveSuffix = ".sops.yaml"
 	}
 	vars := map[string]string{
-		"group":              id.Group,
-		"groupPath":          id.Group,
-		"version":            id.Version,
-		"apiVersion":         apiVersion,
-		"resource":           id.Resource,
-		"kind":               req.Kind,
-		"scope":              scope,
-		"namespace":          id.Namespace,
-		"namespaceOrCluster": nsOrCluster,
-		"name":               id.Name,
-		"sensitiveSuffix":    sensitiveSuffix,
+		"group":           id.Group,
+		"groupPath":       id.Group,
+		"version":         id.Version,
+		"apiVersion":      apiVersion,
+		"resource":        id.Resource,
+		"kind":            req.Kind,
+		"scope":           scope,
+		"namespace":       id.NamespaceOrCluster(),
+		"name":            id.Name,
+		"sensitiveSuffix": sensitiveSuffix,
 	}
 	// Labels join the same map under their full placeholder name. The "label:" prefix is not a
 	// legal bare variable, so a label literally named "namespace" cannot shadow the built-in one.
@@ -805,7 +819,7 @@ func ValidPlacementTemplatePath(tmpl string) error {
 // already complete, never supply the part that is missing.
 func IdentityCompletePlacementTemplate(tmpl string, narrowedToOneType bool) bool {
 	hasName := strings.Contains(tmpl, "{name}")
-	hasScope := strings.Contains(tmpl, "{namespace}") || strings.Contains(tmpl, "{namespaceOrCluster}")
+	hasScope := strings.Contains(tmpl, "{namespace}")
 	if !hasName || !hasScope {
 		return false
 	}

--- a/internal/manifestanalyzer/placement.go
+++ b/internal/manifestanalyzer/placement.go
@@ -492,6 +492,26 @@ func PlacementTypeKey(group, version, resource string) string {
 // "/", so an unrecognized label placeholder pasted through verbatim would split into directories.
 var placementPlaceholderPattern = regexp.MustCompile(`\{[^{}]*\}`)
 
+// strayPlacementBracesError reports a template carrying a brace that is not part of a complete
+// placeholder: "{namespace}/{label:team/{name}.yaml", or a nested "{label:{name}}".
+//
+// placementPlaceholderPattern only finds COMPLETE "{...}" runs, so without this check an unclosed
+// one is not a placeholder at all — it is literal text, and it renders into the path verbatim.
+// That is the exact failure the widened pattern was introduced to prevent, one level up: the
+// example above resolves to "app/{label:team/cache.yaml", a clean relative .yaml path that every
+// later gate accepts, so the writer would create a directory literally named "{label:team".
+// A brace in a path is never what an author meant, so the template is refused instead.
+func strayPlacementBracesError(tmpl string) error {
+	if residue := placementPlaceholderPattern.ReplaceAllString(tmpl, ""); strings.ContainsAny(residue, "{}") {
+		return fmt.Errorf(
+			"placement template %q has a brace that does not open or close a complete variable: "+
+				"every %q and %q must belong to one, such as {name}",
+			tmpl, "{", "}",
+		)
+	}
+	return nil
+}
+
 // placementLabelPrefix introduces the one variable that takes an argument:
 // "{label:app.kubernetes.io/instance}" renders that label's value on the placed resource.
 const placementLabelPrefix = "label:"
@@ -673,9 +693,15 @@ func placementVars(req PlacementRequest) map[string]string {
 // secret-{name}.sops.yaml") against vars, then collapses empty path segments left
 // behind by an omitted variable (e.g. "{groupPath}" for a core resource) so
 // "{groupPath}/{version}/..." renders "v1/..." rather than "/v1/...". It returns an
-// error naming any "{...}"-shaped placeholder that is not a known variable, so a
-// typo in a declared template is caught rather than silently left as literal text.
+// error naming any "{...}"-shaped placeholder that is not a known variable, and any brace that
+// belongs to no complete placeholder at all, so a typo in a declared template is caught rather
+// than silently left in the path as literal text.
 func RenderPlacementTemplate(tmpl string, vars map[string]string) (string, error) {
+	// Before substituting: a stray brace is not a variable this function can fail to resolve, it
+	// is literal text that would be written into the repository as a path segment.
+	if err := strayPlacementBracesError(tmpl); err != nil {
+		return "", err
+	}
 	var unknown []string
 	rendered := placementPlaceholderPattern.ReplaceAllStringFunc(tmpl, func(match string) string {
 		name := strings.Trim(match, "{}")
@@ -747,6 +773,9 @@ func collapseEmptyPathSegments(p string) string {
 // falls back to a fallback/sentinel, is a per-object fact answered at write time. What IS static,
 // and checked here, is that the key itself is one Kubernetes would accept.
 func ValidPlacementTemplateSyntax(tmpl string) error {
+	if err := strayPlacementBracesError(tmpl); err != nil {
+		return err
+	}
 	var unknown []string
 	for _, match := range placementPlaceholderPattern.FindAllString(tmpl, -1) {
 		if !isKnownPlacementVariable(strings.Trim(match, "{}")) {

--- a/internal/manifestanalyzer/placement_label_test.go
+++ b/internal/manifestanalyzer/placement_label_test.go
@@ -373,3 +373,49 @@ func TestLocateNew_EmptyFallback_InAFileNameRendersNothing(t *testing.T) {
 		t.Fatalf("got %q, want %q", res.Path, want)
 	}
 }
+
+// A brace that never closes is not a placeholder at all: placementPlaceholderPattern skips it, so
+// before this check it stayed in the rendered path as literal text and every later gate accepted
+// the result — "{namespace}/{label:team/{name}.yaml" resolved to "app/{label:team/cache.yaml",
+// a clean .yaml path the writer would happily create a "{label:team" directory for.
+func TestPlacementTemplate_StrayBraceIsRejectedEverywhere(t *testing.T) {
+	cases := []struct {
+		tmpl string
+		why  string
+	}{
+		{"{namespace}/{label:team/{name}.yaml", "an unclosed label placeholder swallowed by the next one"},
+		{"{namespace}/{name.yaml", "an unclosed placeholder at the end"},
+		{"{namespace}/name}.yaml", "a closing brace with nothing opening it"},
+		{"{label:{name}}/{name}.yaml", "nested braces"},
+		{"{{name}}/x.yaml", "a doubled brace pair"},
+	}
+	for _, tc := range cases {
+		if err := ValidPlacementTemplateSyntax(tc.tmpl); err == nil {
+			t.Errorf("%s: ValidPlacementTemplateSyntax(%q) = nil, want rejected", tc.why, tc.tmpl)
+		}
+		got, err := RenderPlacementTemplate(tc.tmpl, map[string]string{
+			"namespace": "app", "name": "cache", "label:team": "payments",
+		})
+		if err == nil {
+			t.Errorf("%s: RenderPlacementTemplate(%q) = %q, want rejected", tc.why, tc.tmpl, got)
+		}
+		if got != "" {
+			t.Errorf("%s: RenderPlacementTemplate(%q) returned %q; a refused template renders nothing",
+				tc.why, tc.tmpl, got)
+		}
+	}
+}
+
+// The check must not cost a legal template: a path with no braces at all, and one made only of
+// complete placeholders, both still pass.
+func TestPlacementTemplate_StrayBraceCheckLeavesLegalTemplatesAlone(t *testing.T) {
+	for _, tmpl := range []string{
+		"static/configmaps.yaml",
+		"{namespace}/{label:app.kubernetes.io/instance}/{name}{sensitiveSuffix}",
+		"{label:team|_none}/{groupPath}/{resource}/{name}.yaml",
+	} {
+		if err := ValidPlacementTemplateSyntax(tmpl); err != nil {
+			t.Errorf("ValidPlacementTemplateSyntax(%q) = %v, want accepted", tmpl, err)
+		}
+	}
+}

--- a/internal/manifestanalyzer/placement_label_test.go
+++ b/internal/manifestanalyzer/placement_label_test.go
@@ -1,0 +1,375 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package manifestanalyzer
+
+import (
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+// labeledConfigMapRequest is newConfigMapRequest with metadata.labels attached — the only
+// difference the "{label:key}" variable reads.
+func labeledConfigMapRequest(name string, labels map[string]string) PlacementRequest {
+	req := newConfigMapRequest(name, "app")
+	req.Labels = labels
+	return req
+}
+
+func TestLocateNew_LabelVariable_RendersTheValue(t *testing.T) {
+	store := placementStore(t, fstest.MapFS{})
+	policy := &PlacementPolicy{Default: "{label:team}/{namespaceOrCluster}/{name}.yaml"}
+	req := labeledConfigMapRequest("cache", map[string]string{"team": "payments"})
+
+	res, err := LocateNew(store, policy, req)
+	if err != nil {
+		t.Fatalf("LocateNew: %v", err)
+	}
+	if want := "payments/app/cache.yaml"; res.Path != want || res.Source != PlacementSourceDefault {
+		t.Fatalf("got %+v, want %q from the declared default", res, want)
+	}
+}
+
+// A prefixed key is the common case in practice (app.kubernetes.io/…), and it is the case the
+// widened placeholder pattern exists for: its "/" must be consumed as part of the variable name,
+// never pasted into the path as a directory separator.
+func TestLocateNew_PrefixedLabelKey_IsOneVariableNotTwoSegments(t *testing.T) {
+	store := placementStore(t, fstest.MapFS{})
+	policy := &PlacementPolicy{
+		Default: "{label:app.kubernetes.io/instance}/{name}.yaml",
+	}
+	req := labeledConfigMapRequest("cache", map[string]string{
+		"app.kubernetes.io/instance": "voter",
+	})
+
+	res, err := LocateNew(store, policy, req)
+	if err != nil {
+		t.Fatalf("LocateNew: %v", err)
+	}
+	if want := "voter/cache.yaml"; res.Path != want {
+		t.Fatalf("got %q, want %q", res.Path, want)
+	}
+}
+
+// A resource missing the label is still placed — at the built-in unlabeled sentinel, the same
+// trick {namespaceOrCluster} already uses for "_cluster": a fixed, documented, collision-free
+// value rather than a refusal or an invisible per-deployment default.
+func TestLocateNew_MissingLabel_PlacesAtTheUnlabeledSentinel(t *testing.T) {
+	store := placementStore(t, fstest.MapFS{})
+	policy := &PlacementPolicy{Default: "{label:team}/{namespaceOrCluster}/{name}.yaml"}
+	req := labeledConfigMapRequest("cache", map[string]string{"other": "x"})
+
+	res, err := LocateNew(store, policy, req)
+	if err != nil {
+		t.Fatalf("LocateNew: %v", err)
+	}
+	if want := "_unlabeled/app/cache.yaml"; res.Path != want {
+		t.Fatalf("got %q, want %q", res.Path, want)
+	}
+}
+
+// Kubernetes accepts an empty label value, and an empty segment is dropped from the rendered
+// path — so "present but empty" has to fall back exactly as "absent" does, or every resource
+// carrying the label empty folds onto the wrong file.
+func TestLocateNew_EmptyLabelValue_FallsBackLikeAMissingLabel(t *testing.T) {
+	store := placementStore(t, fstest.MapFS{})
+	policy := &PlacementPolicy{Default: "{label:team}/{namespaceOrCluster}/{name}.yaml"}
+	req := labeledConfigMapRequest("cache", map[string]string{"team": ""})
+
+	res, err := LocateNew(store, policy, req)
+	if err != nil {
+		t.Fatalf("LocateNew: %v", err)
+	}
+	if want := "_unlabeled/app/cache.yaml"; res.Path != want {
+		t.Fatalf("got %q, want %q", res.Path, want)
+	}
+}
+
+// The sentinel is per resource, not per template: an unlabeled resource and its labeled sibling
+// each resolve independently.
+func TestLocateNew_MissingLabel_DoesNotAffectALabeledSibling(t *testing.T) {
+	store := placementStore(t, fstest.MapFS{})
+	policy := &PlacementPolicy{Default: "{label:team}/{namespaceOrCluster}/{name}.yaml"}
+
+	bare, err := LocateNew(store, policy, labeledConfigMapRequest("bare", nil))
+	if err != nil {
+		t.Fatalf("LocateNew for the unlabeled resource: %v", err)
+	}
+	if want := "_unlabeled/app/bare.yaml"; bare.Path != want {
+		t.Fatalf("got %q, want %q", bare.Path, want)
+	}
+	res, err := LocateNew(store, policy,
+		labeledConfigMapRequest("cache", map[string]string{"team": "payments"}))
+	if err != nil {
+		t.Fatalf("LocateNew for the labeled sibling: %v", err)
+	}
+	if want := "payments/app/cache.yaml"; res.Path != want {
+		t.Fatalf("got %q, want %q", res.Path, want)
+	}
+}
+
+// A label is not identity, so it may add discrimination to a sensitive path but can never supply
+// the {name}/scope part that makes one identity-complete.
+func TestIdentityCompletePlacementTemplate_LabelCountsForNothing(t *testing.T) {
+	if IdentityCompletePlacementTemplate("{label:team}/{label:app}.yaml", true) {
+		t.Error("labels alone must not make a template identity-complete")
+	}
+	if !IdentityCompletePlacementTemplate("{label:team}/{namespace}/{name}.yaml", true) {
+		t.Error("a label beside a complete identity must not make the template incomplete")
+	}
+}
+
+func TestValidPlacementTemplateSyntax_Labels(t *testing.T) {
+	cases := []struct {
+		tmpl string
+		ok   bool
+		why  string
+	}{
+		{"{label:team}/{name}.yaml", true, "a bare label key"},
+		{"{label:app.kubernetes.io/name}/{name}.yaml", true, "a prefixed label key"},
+		{"{label:}/{name}.yaml", false, "an empty label key"},
+		{"{label:not a key}/{name}.yaml", false, "a label key with spaces"},
+		{"{label:a//b}/{name}.yaml", false, "a label key with two slashes"},
+		{"{label:-bad}/{name}.yaml", false, "a label name that does not start alphanumeric"},
+		{"{annotation:team}/{name}.yaml", false, "annotations are not a placement variable"},
+	}
+	for _, tc := range cases {
+		err := ValidPlacementTemplateSyntax(tc.tmpl)
+		if tc.ok && err != nil {
+			t.Errorf("%s: ValidPlacementTemplateSyntax(%q) = %v, want accepted", tc.why, tc.tmpl, err)
+		}
+		if !tc.ok && err == nil {
+			t.Errorf("%s: ValidPlacementTemplateSyntax(%q) = nil, want rejected", tc.why, tc.tmpl)
+		}
+	}
+}
+
+// The syntax gate must not need a resource to run: it is the static Validated check, and a label
+// has no value until an object arrives. A template referencing a label it cannot resolve is
+// valid; the resource that does not carry it is refused later, at write time.
+func TestValidPlacementTemplateSyntax_LabelNeedsNoValue(t *testing.T) {
+	if err := ValidPlacementTemplateSyntax("{label:team}/{namespace}/{name}.yaml"); err != nil {
+		t.Fatalf("ValidPlacementTemplateSyntax: %v, want a label template to pass the static gate", err)
+	}
+}
+
+// Widening the placeholder pattern is the load-bearing half of this feature: before it, anything
+// that was not "{word}" was left in the rendered path as literal text, so a mistyped label
+// placeholder would have written its own braces — and its "/" — into the repository.
+func TestRenderPlacementTemplate_MalformedPlaceholderIsReportedNotPastedThrough(t *testing.T) {
+	for _, tmpl := range []string{
+		"{lable:team}/{name}.yaml",
+		"{label:app.kubernetes.io/na me}/{name}.yaml",
+		"{}/{name}.yaml",
+	} {
+		got, err := RenderPlacementTemplate(tmpl, map[string]string{"name": "app"})
+		if err == nil {
+			t.Errorf("RenderPlacementTemplate(%q) = %q, want an unknown-variable error", tmpl, got)
+		}
+	}
+}
+
+// A genuinely unknown variable is still reported, even beside a label placeholder that resolves
+// fine (to the sentinel, since no value is supplied here).
+func TestRenderPlacementTemplate_UnknownVariableIsReportedBesideALabel(t *testing.T) {
+	_, err := RenderPlacementTemplate("{bogus}/{label:team}.yaml", map[string]string{})
+	if err == nil || !strings.Contains(err.Error(), "{bogus}") {
+		t.Fatalf("err = %v, want it to name {bogus}", err)
+	}
+}
+
+func TestPlacementVars_LabelsCannotShadowABuiltInVariable(t *testing.T) {
+	req := labeledConfigMapRequest("cache", map[string]string{"namespace": "hijacked"})
+	vars := placementVars(req)
+	if vars["namespace"] != "app" {
+		t.Errorf("namespace = %q, want the resource's own namespace, not a label of the same name",
+			vars["namespace"])
+	}
+	if vars["label:namespace"] != "hijacked" {
+		t.Errorf("label:namespace = %q, want the label value", vars["label:namespace"])
+	}
+}
+
+// A label value cannot legally contain "/", but the value is read off a live object rather than
+// validated by this package, so the segment defence has to hold for it too.
+func TestRenderPlacementTemplate_SanitizesSlashInALabelValue(t *testing.T) {
+	got, err := RenderPlacementTemplate("{label:team}/{name}.yaml", map[string]string{
+		"label:team": "a/b", "name": "app",
+	})
+	if err != nil {
+		t.Fatalf("RenderPlacementTemplate: %v", err)
+	}
+	if want := "a%2Fb/app.yaml"; got != want {
+		t.Errorf("got %q, want %q (slash percent-encoded, not a path separator)", got, want)
+	}
+}
+
+// An explicit fallback overrides the built-in unlabeled sentinel with the author's own bucket name.
+func TestLocateNew_LabelFallback_OverridesTheSentinel(t *testing.T) {
+	store := placementStore(t, fstest.MapFS{})
+	policy := &PlacementPolicy{Default: "{label:team|unassigned}/{namespaceOrCluster}/{name}.yaml"}
+
+	res, err := LocateNew(store, policy, labeledConfigMapRequest("cache", nil))
+	if err != nil {
+		t.Fatalf("LocateNew: %v", err)
+	}
+	if want := "unassigned/app/cache.yaml"; res.Path != want {
+		t.Fatalf("got %q, want %q", res.Path, want)
+	}
+}
+
+// The fallback is only a fallback: a resource that carries the label is unaffected by it.
+func TestLocateNew_LabelFallback_YieldsToARealValue(t *testing.T) {
+	store := placementStore(t, fstest.MapFS{})
+	policy := &PlacementPolicy{Default: "{label:team|unassigned}/{namespaceOrCluster}/{name}.yaml"}
+
+	res, err := LocateNew(store, policy, labeledConfigMapRequest("cache", map[string]string{"team": "payments"}))
+	if err != nil {
+		t.Fatalf("LocateNew: %v", err)
+	}
+	if want := "payments/app/cache.yaml"; res.Path != want {
+		t.Fatalf("got %q, want %q", res.Path, want)
+	}
+}
+
+// An empty label value is "absent" for the fallback too, matching the sentinel it replaces.
+func TestLocateNew_LabelFallback_CoversAnEmptyValue(t *testing.T) {
+	store := placementStore(t, fstest.MapFS{})
+	policy := &PlacementPolicy{Default: "{label:team|unassigned}/{namespaceOrCluster}/{name}.yaml"}
+
+	res, err := LocateNew(store, policy, labeledConfigMapRequest("cache", map[string]string{"team": ""}))
+	if err != nil {
+		t.Fatalf("LocateNew: %v", err)
+	}
+	if want := "unassigned/app/cache.yaml"; res.Path != want {
+		t.Fatalf("got %q, want %q", res.Path, want)
+	}
+}
+
+// The fallback is author-supplied text that goes straight into a path, so it is fenced by the
+// half of the label-value rules that protects a path segment — no separator, no "..", bounded
+// length — and deliberately NOT by the half that only serves label semantics: a fallback may
+// start with "_", which a label value may not, and may be empty.
+func TestValidPlacementTemplateSyntax_LabelFallback(t *testing.T) {
+	cases := []struct {
+		tmpl string
+		ok   bool
+		why  string
+	}{
+		{"{label:team|unassigned}/{name}.yaml", true, "an ordinary fallback"},
+		{"{label:team|no-team.v2}/{name}.yaml", true, "the dots and dashes a label value allows"},
+		{"{label:team|_none}/{name}.yaml", true, "a leading underscore, which no label value can have"},
+		{"{label:team|_unlabeled}/{name}.yaml", true, "the built-in sentinel, named explicitly"},
+		{"{label:team|}/{name}.yaml", true, "an empty fallback: a declared request to collapse the segment"},
+		{"{label:team|" + strings.Repeat("a", 63) + "}/{name}.yaml", true,
+			"the longest a label value may be"},
+		{"{label:team|" + strings.Repeat("a", 64) + "}/{name}.yaml", false,
+			"one character longer than any label value"},
+		{"{label:team|../escape}/{name}.yaml", false, "a fallback escaping the write jail"},
+		{"{label:team|a/b}/{name}.yaml", false, "a fallback inventing a directory"},
+		{"{label:team|..}/{name}.yaml", false, "a bare parent-directory fallback"},
+		{"{label:team|.}/{name}.yaml", false, "a bare current-directory fallback"},
+		{`{label:team|a\b}/{name}.yaml`, false, "a fallback with a backslash separator"},
+		{"{label:team|has space}/{name}.yaml", false, "a fallback with a space"},
+		{"{label:not a key|x}/{name}.yaml", false, "a bad key is still a bad key with a fallback"},
+	}
+	for _, tc := range cases {
+		err := ValidPlacementTemplateSyntax(tc.tmpl)
+		if tc.ok && err != nil {
+			t.Errorf("%s: ValidPlacementTemplateSyntax(%q) = %v, want accepted", tc.why, tc.tmpl, err)
+		}
+		if !tc.ok && err == nil {
+			t.Errorf("%s: ValidPlacementTemplateSyntax(%q) = nil, want rejected", tc.why, tc.tmpl)
+		}
+	}
+}
+
+func TestPlacementTemplateLabelKeys(t *testing.T) {
+	got := PlacementTemplateLabelKeys(
+		"{label:team}/{namespace}/{label:app.kubernetes.io/instance}/{label:bad key}/{name}.yaml")
+	want := []string{"team", "app.kubernetes.io/instance"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v (malformed keys are left to the syntax check)", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	}
+	if keys := PlacementTemplateLabelKeys("{namespace}/{name}.yaml"); keys != nil {
+		t.Errorf("got %v, want no keys for a template that reads no label", keys)
+	}
+}
+
+// The fallback belongs to the placeholder, not to the key: a caller checking which labels a
+// template reads must see "team", never "team|unassigned".
+func TestPlacementTemplateLabelKeys_StripsTheFallback(t *testing.T) {
+	got := PlacementTemplateLabelKeys("{label:team|unassigned}/{name}.yaml")
+	if len(got) != 1 || got[0] != "team" {
+		t.Fatalf("got %v, want [team]", got)
+	}
+}
+
+// A fallback may start with "_" even though a label value may not, and that is the point: it is
+// the only way a template can name a bucket no real label value will ever land in. The built-in
+// sentinel is spelled this way too, and may be named explicitly.
+func TestLocateNew_UnderscoreFallback_NamesACollisionProofBucket(t *testing.T) {
+	store := placementStore(t, fstest.MapFS{})
+	policy := &PlacementPolicy{Default: "{label:team|_none}/{namespaceOrCluster}/{name}.yaml"}
+
+	res, err := LocateNew(store, policy, labeledConfigMapRequest("cache", nil))
+	if err != nil {
+		t.Fatalf("LocateNew: %v", err)
+	}
+	if want := "_none/app/cache.yaml"; res.Path != want {
+		t.Fatalf("got %q, want %q", res.Path, want)
+	}
+}
+
+// An empty fallback is a declared "no segment here": the resource lands one directory up rather
+// than in a bucket of its own. The sentinel protects the default; a template that spells this out
+// has made the choice in text, so it is honoured.
+func TestLocateNew_EmptyFallback_CollapsesTheSegment(t *testing.T) {
+	store := placementStore(t, fstest.MapFS{})
+	policy := &PlacementPolicy{Default: "{label:team|}/{namespaceOrCluster}/{name}.yaml"}
+
+	res, err := LocateNew(store, policy, labeledConfigMapRequest("cache", nil))
+	if err != nil {
+		t.Fatalf("LocateNew: %v", err)
+	}
+	if want := "app/cache.yaml"; res.Path != want {
+		t.Fatalf("got %q, want %q (the empty fallback drops its segment)", res.Path, want)
+	}
+}
+
+// The empty fallback still only answers for the resources that are missing the label: a labeled
+// sibling keeps its own bucket, so the two do not merge.
+func TestLocateNew_EmptyFallback_LeavesALabeledResourceAlone(t *testing.T) {
+	store := placementStore(t, fstest.MapFS{})
+	policy := &PlacementPolicy{Default: "{label:team|}/{namespaceOrCluster}/{name}.yaml"}
+
+	res, err := LocateNew(store, policy,
+		labeledConfigMapRequest("cache", map[string]string{"team": "payments"}))
+	if err != nil {
+		t.Fatalf("LocateNew: %v", err)
+	}
+	if want := "payments/app/cache.yaml"; res.Path != want {
+		t.Fatalf("got %q, want %q", res.Path, want)
+	}
+}
+
+// An empty fallback in the middle of a FILE NAME rather than of a directory renders nothing at
+// all, because only whole empty segments collapse — the same rule {groupPath} has always followed
+// for a core resource.
+func TestLocateNew_EmptyFallback_InAFileNameRendersNothing(t *testing.T) {
+	store := placementStore(t, fstest.MapFS{})
+	policy := &PlacementPolicy{Default: "{namespaceOrCluster}/{label:team|}-{name}.yaml"}
+
+	res, err := LocateNew(store, policy, labeledConfigMapRequest("cache", nil))
+	if err != nil {
+		t.Fatalf("LocateNew: %v", err)
+	}
+	if want := "app/-cache.yaml"; res.Path != want {
+		t.Fatalf("got %q, want %q", res.Path, want)
+	}
+}

--- a/internal/manifestanalyzer/placement_label_test.go
+++ b/internal/manifestanalyzer/placement_label_test.go
@@ -18,7 +18,7 @@ func labeledConfigMapRequest(name string, labels map[string]string) PlacementReq
 
 func TestLocateNew_LabelVariable_RendersTheValue(t *testing.T) {
 	store := placementStore(t, fstest.MapFS{})
-	policy := &PlacementPolicy{Default: "{label:team}/{namespaceOrCluster}/{name}.yaml"}
+	policy := &PlacementPolicy{Default: "{label:team}/{namespace}/{name}.yaml"}
 	req := labeledConfigMapRequest("cache", map[string]string{"team": "payments"})
 
 	res, err := LocateNew(store, policy, req)
@@ -52,11 +52,11 @@ func TestLocateNew_PrefixedLabelKey_IsOneVariableNotTwoSegments(t *testing.T) {
 }
 
 // A resource missing the label is still placed — at the built-in unlabeled sentinel, the same
-// trick {namespaceOrCluster} already uses for "_cluster": a fixed, documented, collision-free
+// trick {namespace} already uses for "_cluster" on a cluster-scoped resource: a fixed,
 // value rather than a refusal or an invisible per-deployment default.
 func TestLocateNew_MissingLabel_PlacesAtTheUnlabeledSentinel(t *testing.T) {
 	store := placementStore(t, fstest.MapFS{})
-	policy := &PlacementPolicy{Default: "{label:team}/{namespaceOrCluster}/{name}.yaml"}
+	policy := &PlacementPolicy{Default: "{label:team}/{namespace}/{name}.yaml"}
 	req := labeledConfigMapRequest("cache", map[string]string{"other": "x"})
 
 	res, err := LocateNew(store, policy, req)
@@ -73,7 +73,7 @@ func TestLocateNew_MissingLabel_PlacesAtTheUnlabeledSentinel(t *testing.T) {
 // carrying the label empty folds onto the wrong file.
 func TestLocateNew_EmptyLabelValue_FallsBackLikeAMissingLabel(t *testing.T) {
 	store := placementStore(t, fstest.MapFS{})
-	policy := &PlacementPolicy{Default: "{label:team}/{namespaceOrCluster}/{name}.yaml"}
+	policy := &PlacementPolicy{Default: "{label:team}/{namespace}/{name}.yaml"}
 	req := labeledConfigMapRequest("cache", map[string]string{"team": ""})
 
 	res, err := LocateNew(store, policy, req)
@@ -89,7 +89,7 @@ func TestLocateNew_EmptyLabelValue_FallsBackLikeAMissingLabel(t *testing.T) {
 // each resolve independently.
 func TestLocateNew_MissingLabel_DoesNotAffectALabeledSibling(t *testing.T) {
 	store := placementStore(t, fstest.MapFS{})
-	policy := &PlacementPolicy{Default: "{label:team}/{namespaceOrCluster}/{name}.yaml"}
+	policy := &PlacementPolicy{Default: "{label:team}/{namespace}/{name}.yaml"}
 
 	bare, err := LocateNew(store, policy, labeledConfigMapRequest("bare", nil))
 	if err != nil {
@@ -207,7 +207,7 @@ func TestRenderPlacementTemplate_SanitizesSlashInALabelValue(t *testing.T) {
 // An explicit fallback overrides the built-in unlabeled sentinel with the author's own bucket name.
 func TestLocateNew_LabelFallback_OverridesTheSentinel(t *testing.T) {
 	store := placementStore(t, fstest.MapFS{})
-	policy := &PlacementPolicy{Default: "{label:team|unassigned}/{namespaceOrCluster}/{name}.yaml"}
+	policy := &PlacementPolicy{Default: "{label:team|unassigned}/{namespace}/{name}.yaml"}
 
 	res, err := LocateNew(store, policy, labeledConfigMapRequest("cache", nil))
 	if err != nil {
@@ -221,7 +221,7 @@ func TestLocateNew_LabelFallback_OverridesTheSentinel(t *testing.T) {
 // The fallback is only a fallback: a resource that carries the label is unaffected by it.
 func TestLocateNew_LabelFallback_YieldsToARealValue(t *testing.T) {
 	store := placementStore(t, fstest.MapFS{})
-	policy := &PlacementPolicy{Default: "{label:team|unassigned}/{namespaceOrCluster}/{name}.yaml"}
+	policy := &PlacementPolicy{Default: "{label:team|unassigned}/{namespace}/{name}.yaml"}
 
 	res, err := LocateNew(store, policy, labeledConfigMapRequest("cache", map[string]string{"team": "payments"}))
 	if err != nil {
@@ -235,7 +235,7 @@ func TestLocateNew_LabelFallback_YieldsToARealValue(t *testing.T) {
 // An empty label value is "absent" for the fallback too, matching the sentinel it replaces.
 func TestLocateNew_LabelFallback_CoversAnEmptyValue(t *testing.T) {
 	store := placementStore(t, fstest.MapFS{})
-	policy := &PlacementPolicy{Default: "{label:team|unassigned}/{namespaceOrCluster}/{name}.yaml"}
+	policy := &PlacementPolicy{Default: "{label:team|unassigned}/{namespace}/{name}.yaml"}
 
 	res, err := LocateNew(store, policy, labeledConfigMapRequest("cache", map[string]string{"team": ""}))
 	if err != nil {
@@ -315,7 +315,7 @@ func TestPlacementTemplateLabelKeys_StripsTheFallback(t *testing.T) {
 // sentinel is spelled this way too, and may be named explicitly.
 func TestLocateNew_UnderscoreFallback_NamesACollisionProofBucket(t *testing.T) {
 	store := placementStore(t, fstest.MapFS{})
-	policy := &PlacementPolicy{Default: "{label:team|_none}/{namespaceOrCluster}/{name}.yaml"}
+	policy := &PlacementPolicy{Default: "{label:team|_none}/{namespace}/{name}.yaml"}
 
 	res, err := LocateNew(store, policy, labeledConfigMapRequest("cache", nil))
 	if err != nil {
@@ -331,7 +331,7 @@ func TestLocateNew_UnderscoreFallback_NamesACollisionProofBucket(t *testing.T) {
 // has made the choice in text, so it is honoured.
 func TestLocateNew_EmptyFallback_CollapsesTheSegment(t *testing.T) {
 	store := placementStore(t, fstest.MapFS{})
-	policy := &PlacementPolicy{Default: "{label:team|}/{namespaceOrCluster}/{name}.yaml"}
+	policy := &PlacementPolicy{Default: "{label:team|}/{namespace}/{name}.yaml"}
 
 	res, err := LocateNew(store, policy, labeledConfigMapRequest("cache", nil))
 	if err != nil {
@@ -346,7 +346,7 @@ func TestLocateNew_EmptyFallback_CollapsesTheSegment(t *testing.T) {
 // sibling keeps its own bucket, so the two do not merge.
 func TestLocateNew_EmptyFallback_LeavesALabeledResourceAlone(t *testing.T) {
 	store := placementStore(t, fstest.MapFS{})
-	policy := &PlacementPolicy{Default: "{label:team|}/{namespaceOrCluster}/{name}.yaml"}
+	policy := &PlacementPolicy{Default: "{label:team|}/{namespace}/{name}.yaml"}
 
 	res, err := LocateNew(store, policy,
 		labeledConfigMapRequest("cache", map[string]string{"team": "payments"}))
@@ -363,7 +363,7 @@ func TestLocateNew_EmptyFallback_LeavesALabeledResourceAlone(t *testing.T) {
 // for a core resource.
 func TestLocateNew_EmptyFallback_InAFileNameRendersNothing(t *testing.T) {
 	store := placementStore(t, fstest.MapFS{})
-	policy := &PlacementPolicy{Default: "{namespaceOrCluster}/{label:team|}-{name}.yaml"}
+	policy := &PlacementPolicy{Default: "{namespace}/{label:team|}-{name}.yaml"}
 
 	res, err := LocateNew(store, policy, labeledConfigMapRequest("cache", nil))
 	if err != nil {

--- a/internal/manifestanalyzer/placement_test.go
+++ b/internal/manifestanalyzer/placement_test.go
@@ -582,7 +582,7 @@ func TestRenderPlacementTemplate(t *testing.T) {
 	vars := map[string]string{
 		"group": "", "groupPath": "", "version": "v1", "apiVersion": "v1",
 		"resource": "configmaps", "kind": "ConfigMap", "scope": "namespaced",
-		"namespace": "default", "namespaceOrCluster": "default", "name": "app",
+		"namespace": "default", "name": "app",
 		"sensitiveSuffix": ".yaml",
 	}
 	got, err := RenderPlacementTemplate("{groupPath}/{version}/{resource}/{namespace}/{name}.yaml", vars)
@@ -600,10 +600,10 @@ func TestPlacementVars_GroupedClusterScoped(t *testing.T) {
 		Kind:       "ClusterRole",
 	}
 	vars := placementVars(req)
-	if vars["scope"] != "cluster" || vars["namespaceOrCluster"] != "_cluster" {
-		t.Errorf("got scope=%q namespaceOrCluster=%q, want scope=\"cluster\" (descriptor) and "+
-			"namespaceOrCluster=\"_cluster\" (illegal-namespace sentinel) for a cluster-scoped resource",
-			vars["scope"], vars["namespaceOrCluster"])
+	if vars["scope"] != "cluster" || vars["namespace"] != "_cluster" {
+		t.Errorf("got scope=%q namespace=%q, want scope=\"cluster\" (descriptor) and "+
+			"namespace=\"_cluster\" (illegal-namespace sentinel) for a cluster-scoped resource",
+			vars["scope"], vars["namespace"])
 	}
 	if want := "rbac.authorization.k8s.io/v1"; vars["apiVersion"] != want {
 		t.Errorf("apiVersion = %q, want %q for a grouped resource", vars["apiVersion"], want)
@@ -663,15 +663,15 @@ func TestIdentityCompletePlacementTemplate(t *testing.T) {
 		narrowedToOneType bool
 		want              bool
 	}{
-		{"full identity", "{groupPath}/{version}/{resource}/{namespaceOrCluster}/{name}.yaml", false, true},
+		{"full identity", "{groupPath}/{version}/{resource}/{namespace}/{name}.yaml", false, true},
 		{
 			"versionless canonical shape",
-			"{namespaceOrCluster}/{groupPath}/{resource}/{name}.yaml",
+			"{namespace}/{groupPath}/{resource}/{name}.yaml",
 			false,
 			true,
 		},
-		{"missing resource for default", "{groupPath}/{version}/{namespaceOrCluster}/{name}.yaml", false, false},
-		{"missing group for default", "{version}/{resource}/{namespaceOrCluster}/{name}.yaml", false, false},
+		{"missing resource for default", "{groupPath}/{version}/{namespace}/{name}.yaml", false, false},
+		{"missing group for default", "{version}/{resource}/{namespace}/{name}.yaml", false, false},
 		{"narrowed type needs only scope+name", "{namespace}/secret-{name}.sops.yaml", true, true},
 		{"narrowed type missing name", "{namespace}/secret.sops.yaml", true, false},
 		{"narrowed type missing scope", "secret-{name}.sops.yaml", true, false},
@@ -890,5 +890,40 @@ func TestLocateNew_DistinguishesByTypeFromDefault(t *testing.T) {
 	}
 	if fellThrough.Source != PlacementSourceDefault {
 		t.Fatalf("a type no byType entry names must report default, got %s", fellThrough.Source)
+	}
+}
+
+// {namespace} is the ONLY namespace-position variable: for a cluster-scoped resource it renders
+// the "_cluster" sentinel rather than nothing, so the segment never collapses and cluster-scoped
+// resources never scatter into the directory above the one the template named.
+func TestLocateNew_ClusterScoped_RendersTheClusterSentinel(t *testing.T) {
+	store := placementStore(t, fstest.MapFS{})
+	policy := &PlacementPolicy{Default: "{namespace}/{resource}/{name}.yaml"}
+	req := PlacementRequest{
+		Identifier: types.NewResourceIdentifier(
+			"rbac.authorization.k8s.io", "v1", "clusterroles", "", "admin"),
+		Kind: "ClusterRole",
+	}
+
+	res, err := LocateNew(store, policy, req)
+	if err != nil {
+		t.Fatalf("LocateNew: %v", err)
+	}
+	if want := "_cluster/clusterroles/admin.yaml"; res.Path != want {
+		t.Fatalf("got %q, want %q", res.Path, want)
+	}
+}
+
+// The removed variable is reported by name with its replacement. "unknown variable" alone would
+// send its author hunting for a typo that is not there.
+func TestValidPlacementTemplateSyntax_NamespaceOrClusterIsRemovedAndSaysSo(t *testing.T) {
+	err := ValidPlacementTemplateSyntax("{namespaceOrCluster}/{name}.yaml")
+	if err == nil {
+		t.Fatal("{namespaceOrCluster} must be rejected: it no longer exists")
+	}
+	for _, want := range []string{"{namespaceOrCluster} was removed", "{namespace}", "_cluster"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q is missing %q", err.Error(), want)
+		}
 	}
 }

--- a/internal/sanitize/types.go
+++ b/internal/sanitize/types.go
@@ -66,6 +66,13 @@ func cleanAnnotations(annotations map[string]string) map[string]string {
 	return cleaned
 }
 
+// IsStrippedLabel reports whether a label is removed before an object is written to Git.
+//
+// Exported for the GitTarget Validated gate: a placement template reading such a label could
+// never discriminate by it, because the value is gone by the time placement runs. Callers
+// outside this package need the predicate, not the stripping.
+func IsStrippedLabel(key string) bool { return isOperationalLabel(key) }
+
 // isOperationalLabel reports whether a label is controller bookkeeping.
 //
 // Note the asymmetry with Argo CD: its `label` and `annotation+label` tracking

--- a/internal/types/identifier.go
+++ b/internal/types/identifier.go
@@ -95,15 +95,7 @@ func (r ResourceIdentifier) Key() string {
 // splits on that bump. Neither is wrong; they answer different questions, and a caller
 // joining data that outlives a release wants this one.
 func (r ResourceIdentifier) ToGitPath() string {
-	scope := r.Namespace
-	if scope == "" {
-		// Cluster-scoped resource: the scope segment is "_cluster", an illegal
-		// Kubernetes namespace name (DNS-1123 forbids "_"), so it can never collide
-		// with a real namespace and reads unambiguously as "not a namespace" — unlike
-		// a bare "cluster", which is itself a legal namespace name. Matches the
-		// {namespaceOrCluster} placement template variable.
-		scope = "_cluster"
-	}
+	scope := r.NamespaceOrCluster()
 
 	if r.Group == "" {
 		// Core resources (no group): omit the group segment entirely.
@@ -116,6 +108,26 @@ func (r ResourceIdentifier) ToGitPath() string {
 // IsClusterScoped returns true if the resource is cluster-scoped.
 func (r ResourceIdentifier) IsClusterScoped() bool {
 	return r.Namespace == ""
+}
+
+// ClusterScopeSegment is what stands in the namespace position for a cluster-scoped resource:
+// an illegal Kubernetes namespace name (DNS-1123 forbids "_"), so it can never collide with a
+// real namespace and reads unambiguously as "not a namespace" — unlike a bare "cluster", which
+// is itself a legal namespace name.
+//
+// It is one constant rather than a literal per renderer because every surface that names a
+// resource's scope must name it identically: the canonical Git path (ToGitPath), the {namespace}
+// placement variable, and a commit message's .Namespace. There is no second, scope-aware spelling
+// of any of the three — one concept, one word.
+const ClusterScopeSegment = "_cluster"
+
+// NamespaceOrCluster is the resource's namespace, or ClusterScopeSegment when it is
+// cluster-scoped. A cluster-scoped resource HAS a scope name; it is simply not a namespace.
+func (r ResourceIdentifier) NamespaceOrCluster() string {
+	if r.IsClusterScoped() {
+		return ClusterScopeSegment
+	}
+	return r.Namespace
 }
 
 // String returns a human-readable representation.

--- a/test/fixtures/layout-corpus/shapes/3-tree-serialized/README.md
+++ b/test/fixtures/layout-corpus/shapes/3-tree-serialized/README.md
@@ -2,7 +2,7 @@
 
 The built-in canonical layout, and the only shape in this set that needs no layout configuration at
 all: no `placement`, no flag. A path carries the object's identity —
-`{namespaceOrCluster}/{groupPath}/{resource}/{name}.yaml` — and the document carries its namespace,
+`{namespace}/{groupPath}/{resource}/{name}.yaml` — and the document carries its namespace,
 so a file means the same thing wherever it is read.
 
 This is the **viewer** shape. Its first job is that a human, or a diff on a pull request, can see

--- a/test/fixtures/layout-corpus/shapes/3-tree-serialized/config/gittarget.yaml
+++ b/test/fixtures/layout-corpus/shapes/3-tree-serialized/config/gittarget.yaml
@@ -15,7 +15,7 @@ spec:
   # source credential's RBAC bounds what it can actually read.
   # No placement declared and no kustomization anywhere in the subtree, so the
   # ladder falls through to the canonical identity path:
-  #   {namespaceOrCluster}/{groupPath}/{resource}/{name}.yaml
+  #   {namespace}/{groupPath}/{resource}/{name}.yaml
   # This is the only shape in this set that needs no LAYOUT configuration at all.
   # `true` is also what lets the folder hold two source namespaces: the
   # one-source-namespace rule binds only an explicit `false`.

--- a/test/fixtures/layout-corpus/shapes/README.md
+++ b/test/fixtures/layout-corpus/shapes/README.md
@@ -54,7 +54,7 @@ flowchart TD
   P -->|"placement.byType has this GVR"| T1["byType template"]
   P -->|"placement.default is set"| T2["default template"]
   P -->|"neither, and the folder has one kustomize root"| T3["beside the root, {name}.yaml"]
-  P -->|"neither, and it has none"| T4["canonical:<br/>{namespaceOrCluster}/{groupPath}/{resource}/{name}.yaml"]
+  P -->|"neither, and it has none"| T4["canonical:<br/>{namespace}/{groupPath}/{resource}/{name}.yaml"]
 
   T1 --> K{"Does a kustomization<br/>govern that directory?"}
   T2 --> K
@@ -224,7 +224,7 @@ succeeds would be advertising rather than specifying, which is why both halves a
 Shape 3 exists for a use that is not deployment at all: pointing GitOps Reverser at a cluster to
 **see** what is in it, as reviewable documents with a Git history, and never applying the result.
 That is why the tree stays, and it constrains two things. The path has to carry the identity — the
-canonical `{namespaceOrCluster}/{groupPath}/{resource}/{name}.yaml` is what makes a folder browsable
+canonical `{namespace}/{groupPath}/{resource}/{name}.yaml` is what makes a folder browsable
 without an index — and the document has to carry `metadata.namespace`, because a viewer reads one
 file at a time and a file that means something different depending on its folder is not a record.
 


### PR DESCRIPTION
Three changes to the two template languages, which now share one vocabulary.

## 1. Place new files by a label

`spec.placement.byType` and `spec.placement.default` accept `{label:key}`:

```yaml
placement:
  byType:
    v1/configmaps: "{label:app.kubernetes.io/instance}/configmaps.yaml"
```

The key may be prefixed; `{label:app.kubernetes.io/instance}` is one variable, not a variable and a
directory. Resources sharing a value bundle into one file, which is the point of placing by label.

**A missing label never blocks the write.** A resource that does not carry the label, or carries it
with the empty value Kubernetes permits, renders the built-in `_unlabeled` bucket. A label value
must be alphanumeric at both ends, so no real one can ever be `_unlabeled` and no resource lands
there by accident.

This replaces a first cut that refused the resource instead. Refusing traded a wrong-but-visible
outcome for a worse one: a resource nobody had labeled was never written to Git at all, and the gap
showed up only as a refusal counter rather than in the folder or in GitTarget status. For a mirror
whose job is completeness, a silent hole in the observability tool built to catch holes is the one
failure mode not worth having.

`{label:key|fallback}` names your own bucket. A fallback is held to the half of the label-value
rules that keeps a string safe as one path segment (at most 63 characters of `[A-Za-z0-9._-]`,
neither `.` nor `..`), and deliberately not to the half that only serves label semantics:

- **it may start with `_`** — `{label:team|_none}` names a bucket no real label value can reach,
  where a label-legal `{label:team|unassigned}` shares one with resources genuinely labeled
  `team: unassigned` and nothing downstream can separate them again;
- **it may be empty** — `{label:team|}` renders nothing, the segment collapses, and unlabeled
  resources land one directory up. The sentinel protects the case where nobody chose; an empty
  fallback is a choice spelled out in the spec, visible in review.

The placeholder scanner now matches any `{…}` rather than only `{word}`, and every brace must
belong to one complete placeholder, so neither an unrecognized placeholder nor an unclosed one is
pasted into the path as literal text — a label key's `/` must be
consumed as part of the variable, never as a separator. The `Validated` gate also rejects a
template reading a label the writer strips (`kustomize.toolkit.fluxcd.io/*`, `kro.run/*`,
`applyset.kubernetes.io/*`): the value is gone before placement runs, so such a template could
never discriminate by it.

`{annotation:key}` is declined rather than deferred: an annotation value is unbounded text, so it is
not a path segment the way a 63-character label value is.

## 2. One namespace variable (breaking)

`{namespaceOrCluster}` is **removed**. `{namespace}` renders the resource's namespace, or
`_cluster` when it is cluster-scoped.

An empty render is the one thing a path variable must never do: it collapses the segment, so
`{namespace}/{resource}/{name}.yaml` filed a ClusterRole at `clusterroles/admin.yaml` and scattered
cluster-scoped resources into the directory *above* the one the template named — the same silent
fold `_unlabeled` exists to prevent. `{namespaceOrCluster}` existed only to avoid that fold, which
made the safe spelling the longer one and the obvious spelling the trap.

A template still naming it is refused at the `Validated` gate by a message that names the
replacement, rather than the generic "unknown variable" that would send its author hunting for a
typo. Placement is match-first, so nothing already in Git moves; only newly created cluster-scoped
files land at the new path. The `_cluster` sentinel is now `types.ClusterScopeSegment`, one
constant shared by the canonical path, the variable and the commit message field.

## 3. Commit messages read the same nouns

Each `Resources` entry in `liveTemplate` gains `Kind` and `Labels`, `.Namespace` carries the same
`_cluster` sentinel (so the default template drops its `{{if .Namespace}}` guard), and the template
gains `LabelValues` / `LabelValue`:

```yaml
liveTemplate: |-
  chore: sync {{.Count}} resource{{if ne .Count 1}}s{{end}}{{with .LabelValue "team"}} for {{.}}{{end}}

  {{range .Resources -}}
  - [{{.Operation}}] {{.Kind}} {{.Namespace}}/{{.Name}} ({{.Label "app.kubernetes.io/instance"}})
  {{end -}}
```

Read a label with `{{.Label "team"}}`, never `{{.Labels.team}}`: these templates render with
`missingkey=error`, so indexing a label a resource does not carry fails the render, and a failed
render fails the whole commit. The admission validator now renders one sample with labels and one
without, so the dotted form is rejected there rather than mid-window later.

A commit is 1:n, so a label is a set here where a path reads a single value: `LabelValues` is the
sorted distinct list, `LabelValue` the single value when the whole commit agrees on one. The two
differ on a resource that does not carry the label: `LabelValues` skips it, `LabelValue` counts it
as a disagreement and renders nothing. A resource nobody labeled does not abstain — naming a commit
after the only team in it would hide the very resource nobody can attribute. A `DELETE` carries no
object, so `Kind` and `Labels` are empty for one, and a commit containing one is unnamed for the
same reason: what the deleted resource was labeled is not something the window still knows.

`reconcileTemplate` gains no fields, but its **default** now names the namespace of a
namespace-scoped reconcile (`chore: reconcile 4 configmaps in team-a (last resourceVersion: 1331)`),
since a reconcile runs per (type, namespace) cell and such a run covered exactly one namespace.
Without it, a target watching one type in several namespaces wrote identical subjects for each. It
stays behind an `{{if}}` rather than taking the `_cluster` sentinel, and the asymmetry is the point:
per resource, an empty namespace has exactly one meaning, so the sentinel is true; per run, empty
covers both an all-namespaces sweep and a cluster-scoped type, so no word is true of both and the
subject names none.

**The two renderers stay separate on purpose.** A path must be statically checkable — that is what
lets the operator prove a Secret route cannot collide two Secrets onto one file — while a commit
message must iterate over n resources, which needs `range` and `if`. What they now share is the
vocabulary, documented as a table in `configuration.md`. The capitals on the commit side are Go's
(`text/template` reaches only exported fields), not a style choice.

## Validation

`task fmt` → `generate` → `manifests` → `vet` → `lint` → `test` (unit coverage 77.8%, within
tolerance of the 77.9% baseline) → `test-e2e` (85 passed, 0 failed, 23 skipped) all pass on the
final tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added label-based placement paths with fallback handling and an `_unlabeled` bucket.
  - Commit templates can access resource kinds, namespaces, and label values.
  - Cluster-scoped resources consistently use `_cluster` in rendered paths and commit data.
  - Added custom namespace fallback buckets, including empty fallbacks to collapse path segments.

- **Bug Fixes**
  - Invalid placement braces and unsupported or stripped labels are now reported instead of producing unsafe paths.
  - Label values now require agreement across all resources before appearing in commit data.

- **Documentation**
  - Updated configuration, migration, placement, metrics, and upgrade guidance for revised `{namespace}` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
